### PR TITLE
fix issues with double states

### DIFF
--- a/src/src/Components/TypeIcon.js
+++ b/src/src/Components/TypeIcon.js
@@ -45,6 +45,7 @@ import IconAdapter from '@iobroker/adapter-react-v5/Components/Icon';
 const TYPE_ICONS = {
     [Types.airCondition]: TypeIconAC,
     [Types.blind]: TypeIconBlinds,
+    [Types.blindButtons]: TypeIconBlinds,
     [Types.button]: TypeIconButton,
     [Types.buttonSensor]: TypeIconButtonSensor,
     [Types.camera]: TypeIconCamera,

--- a/src/src/Dialogs/DialogEditDevice.js
+++ b/src/src/Dialogs/DialogEditDevice.js
@@ -875,7 +875,7 @@ class DialogEditDevice extends React.Component {
         }
         let props = [item.type || 'any'];
         const dName = item.name.replace(/\d+$/, '%d');
-        //let's try to find the state that has a default role first (fixes issues with double states, for example ON in lights).
+        // let's try to find the state that has a default role first (fixes issues with double states, for example ON in lights).
         let pattern = this.pattern.states.find(state => (state.name === item.name || state.name === dName) && state.defaultRole);
         if (!pattern) {
             pattern = this.pattern.states.find(state => state.name === item.name || state.name === dName);

--- a/src/src/Dialogs/DialogEditDevice.js
+++ b/src/src/Dialogs/DialogEditDevice.js
@@ -875,7 +875,11 @@ class DialogEditDevice extends React.Component {
         }
         let props = [item.type || 'any'];
         const dName = item.name.replace(/\d+$/, '%d');
-        let pattern = this.pattern.states.find(state => state.name === item.name || state.name === dName);
+        //let's try to find the state that has a default role first (fixes issues with double states, for example ON in lights).
+        let pattern = this.pattern.states.find(state => (state.name === item.name || state.name === dName) && state.defaultRole);
+        if (!pattern) {
+            pattern = this.pattern.states.find(state => state.name === item.name || state.name === dName);
+        }
         if (item.write) props.push('write');
         if (item.read) props.push('read');
         if (pattern?.defaultRole) {


### PR DESCRIPTION
Some states in type-detector are duplicated (for example, ON in lights). One of them has no default state (which is good, because it is not shown) but the simple find for some reason tends to find the state without default role, so a role is not assigned, and the state is not detected by type-detector anymore and "lost" after saving.

Now added a second find to make sure that the state with defaultRole is used, if existing.

Not sure if the fallback is needed at all...

Related issues (some together with [type-detector PR](https://github.com/ioBroker/ioBroker.type-detector/pull/31)):
https://github.com/ioBroker/ioBroker.devices/issues/159
https://github.com/ioBroker/ioBroker.devices/issues/141
https://github.com/ioBroker/ioBroker.devices/issues/106
https://github.com/ioBroker/ioBroker.devices/issues/128
