### PR TITLE
add support for Type.cie

### DIFF
--- a/src/src/Components/TypeIcon.js
+++ b/src/src/Components/TypeIcon.js
@@ -69,6 +69,7 @@ const TYPE_ICONS = {
     [Types.ct]: TypeIconCT,
     [Types.rgbSingle]: TypeIconRGBSingle,
     [Types.hue]: TypeIconHUE,
+    [Types.cie]: TypeIconRGB,
     [Types.slider]: TypeIconSlider,
     [Types.socket]: TypeIconSocket,
     [Types.temperature]: TypeIconTemperature,

--- a/src/src/Components/TypeOptions.js
+++ b/src/src/Components/TypeOptions.js
@@ -65,6 +65,7 @@ const TYPE_OPTIONS = {
     [Types.motion]:          { alexa: false, alisa: true,  google: false, material: false },
     [Types.rgbSingle]:       { alexa: false, alisa: true,  google: true,  material: false },
     [Types.rgb]:             { alexa: false, alisa: false, google: true,  material: true  },
+    [Types.cie]:             { alexa: false, alisa: false, google: false, material: false },
     [Types.slider]:          { alexa: false, alisa: false, google: true,  material: false },
     [Types.socket]:          { alexa: true,  alisa: true,  google: true,  material: false },
     [Types.temperature]:     { alexa: false, alisa: true,  google: true,  material: true  },

--- a/src/src/i18n/de.json
+++ b/src/src/i18n/de.json
@@ -66,6 +66,7 @@
     "type-media": "Medien",
     "type-motion": "Bewegung",
     "type-rgb": "RGB-Licht",
+    "type-cie": "CIE Farblicht",
     "type-rgbSingle": "RGB-Licht einzeln",
     "type-slider": "Schieberegler",
     "type-socket": "Steckdose",

--- a/src/src/i18n/en.json
+++ b/src/src/i18n/en.json
@@ -66,6 +66,7 @@
     "type-media": "media",
     "type-motion": "motion",
     "type-rgb": "RGB light",
+    "type-cie": "CIE color light",
     "type-rgbSingle": "RGB light single",
     "type-slider": "slider",
     "type-socket": "socket",

--- a/src/src/i18n/es.json
+++ b/src/src/i18n/es.json
@@ -66,6 +66,7 @@
   "type-media": "medios de comunicación",
   "type-motion": "movimiento",
   "type-rgb": "Luz RGB",
+  "type-cie": "Luz CIE",
   "type-rgbSingle": "Luz RGB individual",
   "type-slider": "control deslizante",
   "type-socket": "enchufe",

--- a/src/src/i18n/fr.json
+++ b/src/src/i18n/fr.json
@@ -66,6 +66,7 @@
     "type-media": "médias",
     "type-motion": "mouvement",
     "type-rgb": "Lumière RVB",
+    "type-cie": "Lumière CIE",
     "type-rgbSingle": "Lumière unique RVB",
     "type-slider": "curseur",
     "type-socket": "prise",

--- a/src/src/i18n/it.json
+++ b/src/src/i18n/it.json
@@ -66,6 +66,7 @@
   "type-media": "media",
   "type-motion": "movimento",
   "type-rgb": "Luce RGB",
+  "type-cie": "Luce CIE",
   "type-rgbSingle": "Luce RGB singola",
   "type-slider": "cursore",
   "type-socket": "presa di corrente",

--- a/src/src/i18n/nl.json
+++ b/src/src/i18n/nl.json
@@ -66,6 +66,7 @@
     "type-media": "media",
     "type-motion": "beweging",
     "type-rgb": "RGB-licht",
+    "type-cie": "CIE-licht",
     "type-rgbSingle": "RGB-licht enkel",
     "type-slider": "schuif",
     "type-socket": "stopcontact",

--- a/src/src/i18n/pl.json
+++ b/src/src/i18n/pl.json
@@ -66,6 +66,7 @@
     "type-media": "głoska bezdźwięczna",
     "type-motion": "ruch",
     "type-rgb": "Światło RGB",
+    "type-cie": "Światło CIE",
     "type-rgbSingle": "Światło pojedyncze RGB",
     "type-slider": "suwak",
     "type-socket": "gniazdo elektryczne",

--- a/src/src/i18n/pt.json
+++ b/src/src/i18n/pt.json
@@ -66,6 +66,7 @@
     "type-media": "meios de comunicação",
     "type-motion": "movimento",
     "type-rgb": "Luz RGB",
+    "type-cie": "Luz CIE",
     "type-rgbSingle": "Luz única RGB",
     "type-slider": "controle deslizante",
     "type-socket": "soquete",

--- a/src/src/i18n/ru.json
+++ b/src/src/i18n/ru.json
@@ -66,6 +66,7 @@
   "type-media": "медиаплайер",
   "type-motion": "движение",
   "type-rgb": "RGB свет",
+  "type-cie": "CIE свет",
   "type-rgbSingle": "RGB свет одиноч.",
   "type-slider": "ползунок",
   "type-socket": "розетка",

--- a/src/src/i18n/zh-cn.json
+++ b/src/src/i18n/zh-cn.json
@@ -66,6 +66,7 @@
     "type-media": "多媒体",
     "type-motion": "运动传感器",
     "type-rgb": "RGB灯",
+    "type-cie": "CIE灯",
     "type-rgbSingle": "RGB灯（单）",
     "type-slider": "滑块",
     "type-socket": "插座",


### PR DESCRIPTION
If https://github.com/ioBroker/ioBroker.type-detector/pull/30 is merged, merge this to add support in devices adapter.

But we might as well skip this here. CIE seems quite obscure choice.