### PR TITLE
fix missing common.read and common.write

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -757,7 +757,7 @@ const isTouchDevice = (): boolean => {
     return (
         'ontouchstart' in window ||
         navigator.maxTouchPoints > 0 ||
-        // @ts-ignore - legacy property
+        // @ts-expect-error - legacy property
         navigator.msMaxTouchPoints > 0
     );
 };


### PR DESCRIPTION
as discussed in #463 `common.read` (and potentially `common.write`) is missing for optional states created by devices adapter. This is because of these two conditions...

Overwriting `common.read` if it is not `undefined` does not make much sense. The change will set it to `true` if `common.read` is  `undefined` (same for `common.write`).