### PR TITLE
fix: resolve prettier error in Universal.tsx that blocks check-and-lint

### DIFF
--- a/src-admin/src/WidgetsManager/Widgets/Universal.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Universal.tsx
@@ -993,11 +993,7 @@ export class WidgetUniversal extends WidgetGeneric<WidgetUniversalState, WidgetU
      * names) from overflowing the tile when CSS `text-overflow: ellipsis` alone would clip
      * too aggressively.
      */
-    private static calcFontSize(
-        text: string,
-        kind: 'value' | 'name',
-        layout: 'compact' | 'wide' | 'wideTall',
-    ): number {
+    private static calcFontSize(text: string, kind: 'value' | 'name', layout: 'compact' | 'wide' | 'wideTall'): number {
         const len = text.length;
         if (kind === 'name') {
             // Name is the secondary line — keep it readable but compact.


### PR DESCRIPTION
The `check-and-lint` job currently fails on `master` with a single `prettier/prettier` error in `src-admin/src/WidgetsManager/Widgets/Universal.tsx:996` (the `calcFontSize` parameter list is wrapped over multiple lines but fits within the print width).

Because `adapter-tests` and `deploy` are gated behind `check-and-lint`, every tagged release since 2.1.1 (2.1.2 – 2.1.5) failed CI and never published — npm `latest` is still 2.1.1 while `master` is at 2.1.5.

This collapses the parameter list to a single line (the output of `eslint --fix`). No logic change.

**Verified locally:** reproduced the failing lint, then ran the full chain `npm run lint` (root → `src-admin` → `packages/dm-widgets`) after the fix → exit 0. This unblocks `check-and-lint`; the test/deploy jobs then run.

Related to #606 (E3031 / failed release runs).
