### PR TITLE
Fix folder-rename data loss and broken ids from dotted device names

### DIFF
--- a/src-admin/src/Dialogs/DialogEditFolder.tsx
+++ b/src-admin/src/Dialogs/DialogEditFolder.tsx
@@ -180,17 +180,24 @@ function DialogEditFolder(props: {
     };
 
     const onChangeCopy = async (): Promise<void> => {
-        let newDevices: PatternControlEx[] = JSON.parse(JSON.stringify(devices));
-
         const parentId = `${getParentId(data!._id)}.${dataEdit.common.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_')}`;
 
-        let deleteFolderID = '';
+        // If the new (sanitized) ID is identical to the current one - only the display name changed,
+        // e.g. "A B" -> "A.B", both sanitize to "A_B" - there is nothing to move. Just update the
+        // folder object in place. Without this guard the loop below would copy every device onto its
+        // own path and then immediately delete it (data loss).
+        if (parentId === data!._id) {
+            await socket.setObject(data!._id, dataEdit);
+            return;
+        }
+
+        let newDevices: PatternControlEx[] = JSON.parse(JSON.stringify(devices));
+
         for (let i = 0; i < arrayObjects.length; i++) {
             const el = arrayObjects[i];
             const newId = el._id.replace(data!._id, parentId);
             if (el.type === 'folder') {
                 await addNewFolder(data!._id === el._id ? dataEdit.common : el.common, newId);
-                deleteFolderID = el._id;
             } else {
                 const device = newDevices.find(device => el._id === device.channelId);
                 if (device?.channelId) {
@@ -201,13 +208,18 @@ function DialogEditFolder(props: {
                         channelObj: el,
                     });
 
-                    newDevices = await deleteDevice(newDevices.indexOf(device));
+                    // Pass `newDevices` so the index refers to the same (progressively spliced) list
+                    // the index was computed against. Without it, deleteDevice cloned the full
+                    // state list and deleted the wrong device from the second device on.
+                    newDevices = await deleteDevice(newDevices.indexOf(device), newDevices);
                 }
             }
         }
 
-        // Delete folder and all object
-        deleteFolderID && (await socket.delObjects(deleteFolderID, true));
+        // Remove the whole old subtree. The renamed folder now lives under a sibling ID, so this does
+        // not touch the freshly created objects. It also cleans up empty old sub-folders, which the
+        // previous code left behind because it only deleted the last iterated folder.
+        await socket.delObjects(data!._id, true);
     };
 
     const onCloseLocal = async (changed?: boolean): Promise<void> => {

--- a/src-admin/src/Dialogs/DialogNewDevice.tsx
+++ b/src-admin/src/Dialogs/DialogNewDevice.tsx
@@ -306,10 +306,10 @@ class DialogNewDevice extends React.Component<DialogNewDeviceProps, DialogNewDev
         if (this.props.deviceToCopy) {
             const channelId = this.props.deviceToCopy.channelId;
             const parentId = getParentId(channelId);
-            return `${parentId || this.state.root}.${this.state.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_')}`;
+            return `${parentId || this.state.root}.${this.state.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_')}`;
         }
 
-        return `${this.state.root}.${this.state.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_')}`;
+        return `${this.state.root}.${this.state.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_')}`;
     }
 
     handleOk = async (): Promise<void> => {


### PR DESCRIPTION
While reorganizing devices in the Device Manager I ran into a few data-integrity issues in the folder-rename and create paths. Each is small and self-contained.

### Renaming a folder could delete the wrong device
`DialogEditFolder.onChangeCopy` moves every contained device to the new path (copy + delete) and called `deleteDevice(index)` without passing the working array. `deleteDevice` then operated on a fresh clone of the full, unchanged device list while the index came from the progressively spliced local list — so from the second device on, the wrong device's states/channel were deleted on the server. Fixed by passing the working list (the function already supports it).

### Renaming a folder with sub-folders left the old folder behind
The old subtree was removed via a single `delObjects(deleteFolderID, true)`, but `deleteFolderID` was overwritten on every folder iteration, so only the last (deepest) sub-folder was deleted and the renamed root folder stayed behind as an empty leftover. Now the whole old subtree is removed once after the copy.

### A no-op rename copied every device onto itself and deleted it
If the new name sanitizes to the same id as the current one (e.g. `A B` → `A.B`, both become `A_B`), the Apply button is not disabled and `onChangeCopy` ran with `parentId === data._id` → every device was copied onto its own path and immediately deleted. Added a guard that updates the folder in place in that case.

### Device names with a "." produced a broken nested id
`DialogNewDevice.generateId` replaced forbidden chars and spaces but not dots, unlike every other id-building path. A name like `Lampe 2.0` produced `alias.0.Lampe_2.0` (a nested object) instead of a single channel. Added the dot replacement.

### Testing
The admin UI has no unit-test harness in this repo, so these are verified by `tsc --noEmit` (check-ts) and `eslint` (both green), plus manual reproduction:
- create a folder with a sub-folder and 2+ alias devices → rename the folder → all devices keep their states, no leftover old folder, nothing wrongly deleted.
- create a device named e.g. "Test 1.5" → the id becomes `…Test_1_5`, not a nested `…Test_1.5`.

Source-only change (`src-admin`); the built `admin/` output is left to the normal build/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
