### PR TITLE
Take over min/max/step/unit from the source state when mapping an alias

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -2698,21 +2698,41 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                                 : state.type
                             : TYPES_MAPPING[state.defaultRole?.split('.')[0] || ''] || 'mixed';
 
-                        /*if (state.defaultMin !== undefined) {
-                            common.min = state.defaultMin;
-                        } else */
-                        if (state.min !== undefined) {
+                        // Take over the value range (min/max/step/unit) from the linked source state
+                        // (#22: e.g. thermostats keep their real range instead of a hard 0..100).
+                        // This is the first-mapping branch; the update branch above leaves an existing
+                        // range untouched, so a manual override is preserved. Skip min/max/step when a
+                        // read conversion is set - the displayed range is then not the source range.
+                        // Fall back to the previous 0/100 default when the source has no explicit range.
+                        const srcTarget = data.ids[state.name];
+                        const srcId = typeof srcTarget === 'string' ? srcTarget : srcTarget?.read;
+                        const srcCommon = srcId
+                            ? (this.objects[srcId]?.common as ioBroker.StateCommon | undefined)
+                            : undefined;
+                        const hasReadFx = !!data.fx[state.name]?.read;
+                        const srcMin = srcCommon?.min;
+                        const srcMax = srcCommon?.max;
+                        const srcStep = srcCommon?.step;
+
+                        if (!hasReadFx && srcMin !== undefined) {
+                            common.min = srcMin;
+                        } else if (state.min !== undefined) {
                             common.min = 0;
                         }
 
-                        /*if (state.defaultMax !== undefined) {
-                            common.max = state.defaultMax;
-                        } else */
-                        if (state.max !== undefined) {
+                        if (!hasReadFx && srcMax !== undefined) {
+                            common.max = srcMax;
+                        } else if (state.max !== undefined) {
                             common.max = 100;
                         }
 
-                        if (state.defaultUnit) {
+                        if (!hasReadFx && srcStep !== undefined) {
+                            common.step = srcStep;
+                        }
+
+                        if (srcCommon?.unit) {
+                            common.unit = srcCommon.unit;
+                        } else if (state.defaultUnit) {
                             common.unit = state.defaultUnit;
                         } else if (state.unit) {
                             common.unit = state.unit;
@@ -2811,21 +2831,41 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                                 : state.type
                             : TYPES_MAPPING[state.defaultRole?.split('.')[0] || ''] || 'mixed';
 
-                        /*if (state.defaultMin !== undefined) {
-                            common.min = state.defaultMin;
-                        } else */
-                        if (state.min !== undefined) {
+                        // Take over the value range (min/max/step/unit) from the linked source state
+                        // (#22: e.g. thermostats keep their real range instead of a hard 0..100).
+                        // This is the first-mapping branch; the update branch above leaves an existing
+                        // range untouched, so a manual override is preserved. Skip min/max/step when a
+                        // read conversion is set - the displayed range is then not the source range.
+                        // Fall back to the previous 0/100 default when the source has no explicit range.
+                        const srcTarget = data.ids[state.name];
+                        const srcId = typeof srcTarget === 'string' ? srcTarget : srcTarget?.read;
+                        const srcCommon = srcId
+                            ? (this.objects[srcId]?.common as ioBroker.StateCommon | undefined)
+                            : undefined;
+                        const hasReadFx = !!data.fx[state.name]?.read;
+                        const srcMin = srcCommon?.min;
+                        const srcMax = srcCommon?.max;
+                        const srcStep = srcCommon?.step;
+
+                        if (!hasReadFx && srcMin !== undefined) {
+                            common.min = srcMin;
+                        } else if (state.min !== undefined) {
                             common.min = 0;
                         }
 
-                        /*if (state.defaultMax !== undefined) {
-                            common.max = state.defaultMax;
-                        } else */
-                        if (state.max !== undefined) {
+                        if (!hasReadFx && srcMax !== undefined) {
+                            common.max = srcMax;
+                        } else if (state.max !== undefined) {
                             common.max = 100;
                         }
 
-                        if (state.defaultUnit) {
+                        if (!hasReadFx && srcStep !== undefined) {
+                            common.step = srcStep;
+                        }
+
+                        if (srcCommon?.unit) {
+                            common.unit = srcCommon.unit;
+                        } else if (state.defaultUnit) {
                             common.unit = state.defaultUnit;
                         } else if (state.unit) {
                             common.unit = state.unit;


### PR DESCRIPTION
Mapping a device state to a source (alias or linked device) generated it with `common.min = 0` / `common.max = 100` hard-coded, ignoring the source's real range — for a thermostat (e.g. 5–35 °C) the visualization then saw 0–100. This is a long-standing limitation, see #22 ("created states do not automatically take over e.g. min and max temperatures … same for dimmers").

Now the value range, step and unit are taken over from the mapped source state's `common`:

- **Only on first mapping** (the create branch). The update branch leaves an existing range untouched, so a manual override (set via the state's edit dialog) is preserved.
- **Skipped when a read conversion function is set**, because the displayed range is then no longer the source's range (e.g. source 0–255 with `val/2.55`).
- **Falls back to the previous 0/100 default** when the source has no explicit range (percentage dimmers/blinds), so nothing regresses.
- Applies to both alias and linkeddevices mapping. The "create new device" path is unchanged (no source mapped there yet).

### Testing
No admin-UI unit-test harness in this repo, so verified via `tsc --noEmit` (check-ts) and `eslint` (both green), plus manual reproduction: map a thermostat SET state whose source has min/max (e.g. 5/35) → the created alias state keeps 5/35 instead of 0/100; a dimmer whose source has no range still gets the 0/100 default.

Source-only change (`src-admin`).

Related to #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
