### PR TITLE
Keep common.custom (logging/smartName) when moving a device

### DIFF
--- a/src-admin/src/Components/helpers/utils.ts
+++ b/src-admin/src/Components/helpers/utils.ts
@@ -314,6 +314,31 @@ export function getAddedChannelStates(
         .filter(item => !channelInfo.states.filter(item => item.defaultRole).find(el => el.name === item.name));
 }
 
+/**
+ * Decide how to treat `common.custom` / `common.smartName` of a state that is being copied.
+ * See the `mode` option of {@link copyDevice}. A `move` keeps everything; only `duplicate` and
+ * `import` strip parts of it.
+ */
+function stripCustomForCopy(common: Record<string, any> | undefined, mode: 'move' | 'duplicate' | 'import'): void {
+    if (!common) {
+        return;
+    }
+    if (mode === 'import') {
+        delete common.custom;
+        delete common.smartName;
+    } else if (mode === 'duplicate') {
+        delete common.smartName;
+        if (common.custom) {
+            for (const key of Object.keys(common.custom)) {
+                if (common.custom[key]?.smartName !== undefined) {
+                    delete common.custom[key].smartName;
+                }
+            }
+        }
+    }
+    // mode === 'move': keep custom (logging) and smartName — it is the same logical device.
+}
+
 export async function copyDevice(
     newChannelId: string,
     options: {
@@ -323,9 +348,19 @@ export async function copyDevice(
         objects: Record<string, ioBroker.Object>;
         channelObj?: ioBroker.FolderObject | ioBroker.ChannelObject | ioBroker.DeviceObject;
         newName?: string;
+        /**
+         * How to treat `common.custom` of the copied states. Defaults to `'move'`.
+         * - `move`: keep everything (same logical device, just relocated) — preserves logging
+         *   (history/influxdb/sql) and smartName.
+         * - `duplicate`: drop only smartName (so the copy does not share the Alexa/Google name);
+         *   keep logging custom.
+         * - `import`: drop all custom (a fresh alias from a native source state).
+         */
+        mode?: 'move' | 'duplicate' | 'import';
     },
 ): Promise<void> {
     const language = options.language || I18n.getLanguage();
+    const mode = options.mode || 'move';
     // if this is a device not from linkeddevices or from alias
     const deviceToCopy: PatternControlEx = JSON.parse(JSON.stringify(options.deviceToCopy));
     renameMultipleEntries(deviceToCopy, options.objects, language);
@@ -405,13 +440,7 @@ export async function copyDevice(
 
         obj.native ||= {};
 
-        if (obj?.common?.custom) {
-            delete obj.common.custom;
-        }
-
-        if (obj?.common?.smartName) {
-            delete obj.common.smartName;
-        }
+        stripCustomForCopy(obj.common, mode);
 
         if (!isAlias) {
             obj.common.alias = { id: state.id };
@@ -429,13 +458,7 @@ export async function copyDevice(
 
         obj.native ||= {};
 
-        if (obj?.common?.custom) {
-            delete obj.common.custom;
-        }
-
-        if (obj?.common?.smartName) {
-            delete obj.common.smartName;
-        }
+        stripCustomForCopy(obj.common, mode);
 
         if (!isAlias) {
             obj.common.alias = { id: state.id };

--- a/src-admin/src/Dialogs/DialogImporter.tsx
+++ b/src-admin/src/Dialogs/DialogImporter.tsx
@@ -333,7 +333,7 @@ export default function DialogImporter(props: {
     devices: PatternControlEx[];
     objects: Record<string, ioBroker.Object>;
     listItems: ListItem[];
-    onCopyDevice: (fromId: string, toId: string) => Promise<void>;
+    onCopyDevice: (fromId: string, toId: string, mode?: 'move' | 'duplicate' | 'import') => Promise<void>;
     theme: IobTheme;
     themeType: ThemeType;
 }): React.JSX.Element {
@@ -465,7 +465,7 @@ export default function DialogImporter(props: {
 
     const addDevice = async (id: string, el: ListItem): Promise<void> => {
         const newId = `${id}.${el.title.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_')}`;
-        await onCopyDevice(el.id, newId);
+        await onCopyDevice(el.id, newId, 'import');
     };
 
     const checkDeviceInObjects = (name: string, id: string): boolean => {

--- a/src-admin/src/Dialogs/DialogNewDevice.tsx
+++ b/src-admin/src/Dialogs/DialogNewDevice.tsx
@@ -321,6 +321,7 @@ class DialogNewDevice extends React.Component<DialogNewDeviceProps, DialogNewDev
                 deviceToCopy: this.props.deviceToCopy,
                 language: I18n.getLanguage(),
                 objects: this.props.objects,
+                mode: 'duplicate',
             });
             this.props.onClose();
         } else {

--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -2548,7 +2548,11 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
         }
     };
 
-    onCopyDevice = async (id: string, newChannelId: string): Promise<void> => {
+    onCopyDevice = async (
+        id: string,
+        newChannelId: string,
+        mode: 'move' | 'duplicate' | 'import' = 'move',
+    ): Promise<void> => {
         // if this is a device not from linkeddevices or from alias
         const deviceToCopy = this.state.devices.find(device => device.channelId === id);
 
@@ -2557,6 +2561,7 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                 socket: this.props.socket,
                 objects: this.objects,
                 deviceToCopy: deviceToCopy,
+                mode,
             });
         }
     };


### PR DESCRIPTION
Moving a device in the Device Manager is implemented as copy + delete (drag & drop, folder rename and device rename all go through `copyDevice`). `copyDevice` unconditionally deleted `common.custom` and `common.smartName` on every copied state, so moving a device silently wiped the history/InfluxDB/SQL logging configuration of all its states (and the adapter's GUI-enabled flag). This is the secondary complaint in #151 ("InfluxDB Settings got lost after moving devices").

`copyDevice` gets a `mode` option (default `'move'`):

- **move**: keep everything — it is the same logical device, just relocated.
- **duplicate**: drop only smartName (top level and per-instance) so a copied device does not share the original's Alexa/Google name; keep the logging custom.
- **import**: drop all custom — a fresh alias built from a native source state (previous behavior).

The move paths (drag, folder rename, device rename) rely on the default and now preserve custom. Only the "copy device" dialog opts into `duplicate` and the importer into `import`.

### Testing
No admin-UI unit-test harness in this repo, so verified via `tsc --noEmit` (check-ts) and `eslint` (both green), plus manual reproduction: a device whose states carry `custom.influxdb.0` logging, moved to another folder, keeps its logging on the new ids (previously it was gone).

Source-only change (`src-admin`).

Related to #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
