### PR TITLE
Keep all edits when renaming a device together with other changes

### DIFF
--- a/src-admin/src/Components/helpers/utils.ts
+++ b/src-admin/src/Components/helpers/utils.ts
@@ -347,7 +347,7 @@ export async function copyDevice(
         }
     }
 
-    const { functions, rooms, icon, states, color, type } = deviceToCopy;
+    const { functions, rooms, states, type } = deviceToCopy;
     const tasks: {
         id: string;
         obj: ioBroker.Object;
@@ -369,10 +369,10 @@ export async function copyDevice(
                 name: options.newName
                     ? ({ [language]: options.newName } as ioBroker.StringOrTranslated)
                     : originalChannelObj.common.name,
-                color: color || undefined,
+                color: originalChannelObj.common.color || undefined,
                 desc: originalChannelObj.common.desc,
                 role: role?.defaultChannelRole || type,
-                icon: (icon?.startsWith('adapter/') ? `../../${icon}` : icon) || undefined,
+                icon: originalChannelObj.common.icon || undefined,
             },
             type: 'channel',
             native: originalChannelObj.native || {},

--- a/src-admin/src/Dialogs/DialogEditDevice.tsx
+++ b/src-admin/src/Dialogs/DialogEditDevice.tsx
@@ -371,7 +371,7 @@ interface DialogEditDeviceProps {
         channelInfo?: PatternControlEx,
     ) => Promise<void>;
     onSaveProperties: (properties: DialogEditPropertiesState, channelInfo: PatternControlEx) => Promise<void>;
-    onCopyDevice: (id: string, newChannelId: string) => Promise<void>;
+    onCopyDevice: (id: string, newChannelId: string, functions?: string[], rooms?: string[]) => Promise<void>;
 }
 
 interface DialogEditDeviceState {
@@ -991,7 +991,12 @@ class DialogEditDevice extends React.Component<DialogEditDeviceProps, DialogEdit
             parts.pop();
             let lastPart = parts.join('.');
             lastPart = `${lastPart}.${this.state.changeProperties.name.replace(Utils.FORBIDDEN_CHARS, '_').replace(/\s/g, '_').replace(/\./g, '_')}`;
-            await this.props.onCopyDevice(this.channelId, lastPart);
+            await this.props.onCopyDevice(
+                this.channelId,
+                lastPart,
+                this.state.changeProperties.functions,
+                this.state.changeProperties.rooms,
+            );
         }
         this.setState({ startTheProcess: false });
         void this.props.onClose(null);

--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -2963,8 +2963,30 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                 iotNoCommon={this.state.iotNoCommon}
                 socket={this.props.socket}
                 instance={`${this.props.adapterName}.${this.props.instance}`}
-                onCopyDevice={async (id, newId) => {
+                onCopyDevice={async (id, newId, functions, rooms) => {
+                    // The edits (name, mappings, possibly newly mapped states) were just written to
+                    // the OLD objects. copyDevice reads from the cache, so refresh the channel and its
+                    // states first - otherwise the renamed copy would miss them, or skip a state that
+                    // was mapped in this same session and still has a stale empty id in deviceToCopy.
+                    const dev = this.state.devices.find(device => device.channelId === id);
+                    const refreshIds = [id, ...(dev?.states || []).map(state => `${id}.${state.name}`)];
+                    for (const refreshId of refreshIds) {
+                        try {
+                            const obj = await this.props.socket.getObject(refreshId);
+                            if (obj) {
+                                this.objects[refreshId] = obj;
+                            } else {
+                                delete this.objects[refreshId];
+                            }
+                        } catch {
+                            // ignore
+                        }
+                    }
                     await this.onCopyDevice(id, newId);
+                    // Apply the (possibly changed) room/function selection to the new channel id.
+                    if (functions || rooms) {
+                        await this.setEnumsOfDevice(newId, functions, rooms);
+                    }
                     const copiedDevice = this.state.devices.find(device => device.channelId === id);
                     if (copiedDevice) {
                         await this.deleteDevice(this.state.devices.indexOf(copiedDevice));


### PR DESCRIPTION
Renaming a device in the edit dialog is implemented as a copy to the new (name based) id followed by a delete of the old one. The copy read the channel and its states from the in-memory cache, which still held the **pre-edit** state. So changing the name together with room/function/mapping/color/icon changes saved only part of them, and a state that was mapped in the same edit session — still carrying a stale empty id in the detected device — was skipped entirely and lost. See #513 ("copied & moved devices dont save changes at once") and #360.

Fix, in the edit dialog's `onCopyDevice` path:

- Before the copy, refresh the cache for the channel and its states from the server, so the copy reflects the just-saved name/mappings and discovers states mapped in this session.
- After the copy, apply the current room/function selection to the new id (the new functions/rooms are threaded through the callback).
- The new channel's color/icon are sourced from the freshly-read channel object instead of the cached detected device, so a color/icon change made in the same edit is carried over too — and an inherited display icon is no longer baked into the copied channel.

### Testing
No admin-UI unit-test harness in this repo, so verified via `tsc --noEmit` (check-ts) and `eslint` (both green), plus manual reproduction: rename a device and change its room/color in the same edit → the renamed device keeps the new room, color and all state mappings; map a previously-empty state and rename in the same edit → the mapped state survives.

Source-only change (`src-admin`).

Related to #513, #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
