### PR TITLE
Fix alias devices listing datapoints from other devices (#597, #536)

### DIFF
--- a/src-admin/src/Devices/SmartDetector.ts
+++ b/src-admin/src/Devices/SmartDetector.ts
@@ -34,3 +34,40 @@ export default class IOBChannelDetector {
         return this.detector.detect(options);
     }
 }
+
+/**
+ * Devices-side guard for type-detector issue #597 / #536.
+ *
+ * When several independent aliases are grouped under one alias *device*, the
+ * type-detector merges them into a single detected device: it fills the device's
+ * slots — indicators (UNREACH, LOWBAT, ERROR) as well as regular states like
+ * ON_ACTUAL — from the sibling channels of that grouping. The detected device then
+ * lists datapoints that belong to completely different devices (see the issue
+ * screenshots: a motion alias showing a Shelly's "online", or a dimmer showing
+ * another light's status).
+ *
+ * We drop mappings that are aliases sitting in a *different* alias channel than the
+ * device's primary (required) state. Required states are never dropped, and real
+ * hardware states carry no `common.alias`, so genuine device-level states on a
+ * neighbouring channel (e.g. a Homematic LOWBAT on the .0 channel) stay untouched.
+ */
+export function removeForeignAliasStates(control: PatternControl, objects: Record<string, ioBroker.Object>): void {
+    const primary = control.states.find(s => s.id && s.required) || control.states.find(s => s.id);
+    if (!primary?.id) {
+        return;
+    }
+    const homeChannel = primary.id.substring(0, primary.id.lastIndexOf('.'));
+    for (const state of control.states) {
+        if (!state.id || state.required) {
+            continue;
+        }
+        const common = objects[state.id]?.common as ioBroker.StateCommon | undefined;
+        if (!common?.alias) {
+            // real hardware (no alias) – keep genuine device-level states
+            continue;
+        }
+        if (state.id.substring(0, state.id.lastIndexOf('.')) !== homeChannel) {
+            state.id = '';
+        }
+    }
+}

--- a/src-admin/src/Dialogs/DialogEditDevice.tsx
+++ b/src-admin/src/Dialogs/DialogEditDevice.tsx
@@ -52,6 +52,7 @@ import {
     extendDeviceTypeTranslation,
 } from '@iobroker/adapter-react-v5';
 import ChannelDetector, { type Types, type DetectorState, type ExternalPatternControl } from '@iobroker/type-detector';
+import { removeForeignAliasStates } from '../Devices/SmartDetector';
 
 import DialogEditProperties, { type DialogEditPropertiesState } from './DialogEditProperties';
 import DialogAddState from './DialogAddState';
@@ -787,6 +788,10 @@ class DialogEditDevice extends React.Component<DialogEditDeviceProps, DialogEdit
         if (!detected?.length) {
             return;
         }
+
+        // #597/#536: strip indicator datapoints that leaked in from sibling channels
+        // of an alias-device grouping so auto-fill does not re-introduce them.
+        detected.forEach(control => removeForeignAliasStates(control, this.props.objects));
 
         // Use the first detection result matching our device type
         const match = detected.find(d => d.type === deviceType);

--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -97,7 +97,7 @@ import {
     setSmartName,
 } from '../Components/helpers/utils';
 import type { PatternControlEx, ListItem } from '../types';
-import SmartDetector from '../Devices/SmartDetector';
+import SmartDetector, { removeForeignAliasStates } from '../Devices/SmartDetector';
 import DialogEdit from '../Dialogs/DialogEditDevice';
 import DialogNew from '../Dialogs/DialogNewDevice';
 import LocalUtils from '../Components/helpers/LocalUtils';
@@ -1207,7 +1207,12 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                 _keysOptional: keys,
                 ignoreCache: true,
             });
-            result?.forEach(device => devices.push(device as PatternControlEx));
+            result?.forEach(device => {
+                // #597/#536: drop indicator datapoints that leaked in from sibling
+                // channels of an alias-device grouping before they reach the UI.
+                removeForeignAliasStates(device, this.objects);
+                devices.push(device as PatternControlEx);
+            });
             if (di % DETECT_CHUNK === DETECT_CHUNK - 1) {
                 await new Promise(resolve => setTimeout(resolve));
                 if (detectGen !== this.detectGeneration) {

--- a/src/lib/WidgetsManagement.ts
+++ b/src/lib/WidgetsManagement.ts
@@ -31,6 +31,38 @@ function getParentId(id: string): string {
     return pos !== -1 ? id.substring(0, pos) : '';
 }
 
+/**
+ * Devices-side guard for type-detector issue #597 / #536 (twin of
+ * `removeForeignAliasStates` in src-admin/src/Devices/SmartDetector.ts).
+ *
+ * When several independent aliases are grouped under one alias device, the
+ * type-detector fills the detected device's slots — indicators as well as regular
+ * states — from the sibling channels of that grouping, so the device ends up
+ * carrying datapoints of completely different devices. We drop mappings that are
+ * aliases sitting in a different alias channel than the device's primary (required)
+ * state. Required states are never dropped, and real hardware states carry no
+ * `common.alias`, so genuine device-level indicators on a neighbouring channel stay.
+ */
+function removeForeignAliasStates(device: DevicesPatternControl, objects: Record<string, ioBroker.Object>): void {
+    const primaryId = findMainStateId(device) || device.states.find(s => s.id)?.id;
+    if (!primaryId) {
+        return;
+    }
+    const homeChannel = getParentId(primaryId);
+    for (const state of device.states) {
+        if (!state.id || state.required) {
+            continue;
+        }
+        const common = objects[state.id]?.common as ioBroker.StateCommon | undefined;
+        if (!common?.alias) {
+            continue;
+        }
+        if (getParentId(state.id) !== homeChannel) {
+            state.id = '';
+        }
+    }
+}
+
 export default class DevicesWidgetsManagement extends WidgetsManagement<DevicesAdapter> {
     private readonly detector = new ChannelDetector();
     private objects: Record<string, ioBroker.Object> = {};
@@ -369,6 +401,8 @@ export default class DevicesWidgetsManagement extends WidgetsManagement<DevicesA
             if (detected) {
                 for (const device of detected) {
                     const d = device as DevicesPatternControl;
+                    // #597/#536: strip datapoints leaked from sibling channels of an alias grouping
+                    removeForeignAliasStates(d, this.objects);
                     this.resolveChannelId(d);
                     if (d.storeId) {
                         result.push(d);


### PR DESCRIPTION
## The problem

A user creates an alias for a device — e.g. a Homematic motion sensor — mapping a few datapoints with the Alias Manager. Opening that alias in the **Devices** tab then shows **extra datapoints that belong to completely different devices**:

- **#597**: a motion alias lists a Shelly plug's `online` as UNREACH, another Homematic's LOWBAT, and a third device's ERROR_CODE.
- **#536**: a dimmer alias lists another light's status as ON_ACTUAL (the reporter annotated it "Another device").

## Root cause

In both reports the aliases were grouped under one alias **device** (`alias.0.<Room>` created as a `device` that holds one channel per logical device). Given that device, the type-detector correctly treats it as a single device and fills its slots — indicators **and** regular states — from **all** sibling channels. That is right for real hardware (a Homematic device shares device-level LOWBAT/UNREACH across its channels) but wrong for an alias grouping of unrelated devices.

It is not purely cosmetic: the leaked slots point at other devices' alias objects, so clearing such a slot in the edit dialog deletes that other device's state, and changing it overwrites it.

## The fix (devices side — type-detector untouched)

After detection, drop state mappings that are aliases sitting in a **different alias channel** than the device's primary (required) state. Required states are never dropped; real hardware states carry no `common.alias`, so genuine device-level indicators on a neighbouring channel stay intact. Applied at every place the adapter runs the detector: the list detection (`ListDevices`), the edit dialog's auto-fill (`DialogEditDevice`) and the device-manager backend (`WidgetsManagement`).

## Verification

Reproduced against the bundled `@iobroker/type-detector` 5.0.13:

- the motion grouping produces exactly the three foreign sources from #597; after the fix only the real motion + brightness remain;
- the dimmer grouping produces the foreign ON_ACTUAL from #536; after the fix only the real dimmer states remain;
- a real Homematic device keeps its device-level LOWBAT/UNREACH on the neighbouring `.0` channel;
- a legitimate single-channel alias device — even one whose datapoints alias to different physical sources — is left completely intact.

`check-ts`, `eslint` and the admin + backend builds all pass.

## Scope / limitation

The guard targets aliases; `common.alias`-less states (real hardware, linkeddevices) are not touched. If someone deliberately built one coherent alias device spread across several channels, states outside the primary channel would be dropped — this layout does not occur with aliases created through the Devices tab / Alias Manager. A whole grouping may still be surfaced as an aggregate `Information` device; whether such groupings should be listed at all is a separate, product-level question.

Addresses #597
Addresses #536
