### PR TITLE
Ensure instance monitoring objects (alive/connected) exist

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,8 @@ export default class DevicesAdapter extends Adapter {
         const systemConfig = await this.getForeignObjectAsync('system.config');
         this.language = systemConfig?.common?.language || 'en';
         this.subscribeForeignObjects('*');
+        // Repair missing instance monitoring objects (see #603) so the admin does not show us red.
+        await this.ensureInstanceStateObjects();
         await this.onInstall(true);
 
         // Upload one picture to devices.0, so it will be available in the File selector
@@ -66,6 +68,40 @@ export default class DevicesAdapter extends Adapter {
         // the instance must either run `usePureWebSockets` or delegate the socket layer to a
         // `ws.X` adapter instance via `native.socketio`.
         await this.checkWebInstances();
+    }
+
+    /**
+     * Ensure the instance monitoring objects `alive` and `connected` exist.
+     *
+     * js-controller creates these when the instance is set up, but on some upgraded
+     * installations the objects go missing while their state values persist. That makes the
+     * admin "Instances" tab render this instance red for a few seconds whenever the tab is
+     * opened, because the object-based state snapshot skips object-less states (issue #603).
+     * `setForeignObjectNotExistsAsync` is idempotent, so healthy instances stay untouched.
+     */
+    private async ensureInstanceStateObjects(): Promise<void> {
+        await this.setForeignObjectNotExistsAsync(`system.adapter.${this.namespace}.alive`, {
+            type: 'state',
+            common: {
+                name: `${this.namespace} alive`,
+                type: 'boolean',
+                read: true,
+                write: true,
+                role: 'indicator.state',
+            },
+            native: {},
+        });
+        await this.setForeignObjectNotExistsAsync(`system.adapter.${this.namespace}.connected`, {
+            type: 'state',
+            common: {
+                name: `${this.namespace} is connected`,
+                type: 'boolean',
+                read: true,
+                write: false,
+                role: 'indicator.state',
+            },
+            native: {},
+        });
     }
 
     private async checkWebInstances(): Promise<void> {


### PR DESCRIPTION
### Symptom

The `devices` instance is shown **red** in the admin *Instances* tab for a few seconds every time the tab is opened (or after a browser refresh), then turns green. It happens only for `devices`, not for other adapters, and nothing is logged — even in debug. Reported in #603 and in the forum (topic 84587); the workaround users found was to delete and re-create the instance.

### Root cause

On the affected installations the instance monitoring **objects** `system.adapter.devices.<n>.alive` and `system.adapter.devices.<n>.connected` are missing, while their **state values** still exist (js-controller keeps writing them via the heartbeat).

When the Instances tab loads, its object-based state snapshot (`getForeignStates('system.adapter.*')`) skips the object-less states, so `alive`/`connected` are briefly absent from the admin's cache and `getInstanceStatus()` evaluates `!alive || !connected` → **red**. The live state subscription then delivers a heartbeat and the row turns green.

This is specific to `devices`: other `connectionType: none` daemon adapters (e.g. `javascript`) still have both objects. The current code neither deletes nor recreates them, so once they are gone (older version / upgrade) the situation persists.

### Fix

Recreate the two objects idempotently on start with `setForeignObjectNotExistsAsync`, modeled on the standard instance-state objects (`boolean`, role `indicator.state`). Healthy instances are left untouched; affected instances self-heal on the next start — no data loss, unlike delete-and-recreate.

### How it was verified

On a live system with the objects missing (red confirmed in Safari and Firefox):

- Creating the two objects → the instance turns **green immediately** and stays green across tab switches and force-refresh.
- The objects **survive an adapter restart** — nothing removes them again.
- `getForeignStates('system.adapter.devices.0.*')` returned the states again once the objects existed (it was empty before).

`npm run build:backend` and `eslint` pass.

Addresses #603.
