### PR TITLE
Always confirm recursive folder deletion and warn about its contents

### DIFF
--- a/src-admin/src/Dialogs/DialogDeleteFolder.tsx
+++ b/src-admin/src/Dialogs/DialogDeleteFolder.tsx
@@ -48,19 +48,21 @@ export default function DialogDeleteFolder(props: {
                 {I18n.t(
                     device
                         ? 'Device and all states will be deleted. Are you sure?'
-                        : 'Folder will be deleted. Are you sure?',
+                        : 'Folder and all its devices and states will be deleted. Are you sure?',
                 )}
-                <div style={styles.showDialog}>
-                    <FormControlLabel
-                        control={
-                            <Checkbox
-                                checked={checked}
-                                onChange={e => setChecked(e.target.checked)}
-                            />
-                        }
-                        label={I18n.t('Do not show dialog for 5 minutes')}
-                    />
-                </div>
+                {device ? (
+                    <div style={styles.showDialog}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={checked}
+                                    onChange={e => setChecked(e.target.checked)}
+                                />
+                            }
+                            label={I18n.t('Do not show dialog for 5 minutes')}
+                        />
+                    </div>
+                ) : null}
             </DialogContent>
             <DialogActions>
                 <Button

--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -1782,12 +1782,12 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
 
     renderDeleteDialog(): React.JSX.Element | null {
         if (this.state.deleteFolderAndDevice) {
-            const time = parseInt(
-                window.localStorage.getItem(
-                    this.state.deleteFolderAndDevice.device ? 'DeleteDeviceTime' : 'DeleteFolderTime',
-                ) || '0',
-                10,
-            );
+            // Deleting a folder is recursive (removes all contained devices and states), so it
+            // always requires an explicit confirmation. Only single devices may be removed without
+            // re-confirmation within the 5-minute window.
+            const time = this.state.deleteFolderAndDevice.device
+                ? parseInt(window.localStorage.getItem('DeleteDeviceTime') || '0', 10)
+                : 0;
             if (time && Date.now() - time < 5 * 60_000) {
                 const deleteFolderAndDevice: { id: string; device?: false } | { index: number; device: true } =
                     JSON.parse(JSON.stringify(this.state.deleteFolderAndDevice));

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -52,6 +52,7 @@
     "Filter": "Filter",
     "Folder name": "Ordnername",
     "Folder will be deleted. Are you sure?": "Der Ordner wird gelöscht. Bist du sicher?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Der Ordner und alle enthaltenen Geräte und Zustände werden gelöscht. Bist du sicher?",
     "Function": "Funktion",
     "Functions": "Funktionen",
     "GUI": "GUI",

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -52,6 +52,7 @@
     "Filter": "Filter",
     "Folder name": "Folder name",
     "Folder will be deleted. Are you sure?": "Folder will be deleted. Are you sure?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Folder and all its devices and states will be deleted. Are you sure?",
     "Function": "Function",
     "Functions": "Functions",
     "GUI": "GUI",

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -52,6 +52,7 @@
     "Filter": "Filtrar",
     "Folder name": "Nombre de la carpeta",
     "Folder will be deleted. Are you sure?": "Se eliminará la carpeta. ¿Está seguro?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Se eliminarán la carpeta y todos sus dispositivos y estados. ¿Está seguro?",
     "Function": "Función",
     "Functions": "Las funciones",
     "GUI": "Interfaz gráfica de usuario",

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -52,6 +52,7 @@
     "Filter": "Filtre",
     "Folder name": "Nom de dossier",
     "Folder will be deleted. Are you sure?": "Le dossier sera supprimé. Êtes-vous sûr?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Le dossier et tous ses appareils et états seront supprimés. Êtes-vous sûr?",
     "Function": "Une fonction",
     "Functions": "Les fonctions",
     "GUI": "Interface graphique",

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -52,6 +52,7 @@
     "Filter": "Filtro",
     "Folder name": "Nome della cartella",
     "Folder will be deleted. Are you sure?": "La cartella verrà eliminata. Sei sicuro?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "La cartella e tutti i suoi dispositivi e stati verranno eliminati. Sei sicuro?",
     "Function": "Funzione",
     "Functions": "funzioni",
     "GUI": "GUI",

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -52,6 +52,7 @@
     "Filter": "Filter",
     "Folder name": "Naam van de map",
     "Folder will be deleted. Are you sure?": "Map wordt verwijderd. Weet je het zeker?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "De map en alle apparaten en statussen worden verwijderd. Weet je het zeker?",
     "Function": "Functie",
     "Functions": "functies",
     "GUI": "GUI",

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -52,6 +52,7 @@
     "Filter": "Filtr",
     "Folder name": "Nazwa folderu",
     "Folder will be deleted. Are you sure?": "Folder zostanie usunięty. Jesteś pewny?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Folder oraz wszystkie jego urządzenia i stany zostaną usunięte. Jesteś pewny?",
     "Function": "Funkcja",
     "Functions": "Funkcje",
     "GUI": "Interfejs graficzny",

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -52,6 +52,7 @@
     "Filter": "Filtro",
     "Folder name": "Nome da pasta",
     "Folder will be deleted. Are you sure?": "A pasta será excluída. Tem certeza?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "A pasta e todos os seus dispositivos e estados serão excluídos. Tem certeza?",
     "Function": "Função",
     "Functions": "Funções",
     "GUI": "GUI",

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -52,6 +52,7 @@
     "Filter": "Фильтр",
     "Folder name": "Имя папки",
     "Folder will be deleted. Are you sure?": "Папка будет удалена. Подтвердить?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Папка и все её устройства и состояния будут удалены. Подтвердить?",
     "Function": "Функция",
     "Functions": "Функции",
     "GUI": "Графический интерфейс пользователя",

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -52,6 +52,7 @@
     "Filter": "фільтр",
     "Folder name": "Назва папки",
     "Folder will be deleted. Are you sure?": "Папку буде видалено. Ти впевнений?",
+    "Folder and all its devices and states will be deleted. Are you sure?": "Папку та всі її пристрої і стани буде видалено. Ти впевнений?",
     "Function": "функція",
     "Functions": "Функції",
     "GUI": "Графічний інтерфейс користувача",

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -52,6 +52,7 @@
     "Filter": "过滤",
     "Folder name": "文件夹名称",
     "Folder will be deleted. Are you sure?": "文件夹将被删除。你确定吗？",
+    "Folder and all its devices and states will be deleted. Are you sure?": "文件夹及其所有设备和状态将被删除。你确定吗？",
     "Function": "功能",
     "Functions": "功能",
     "GUI": "图形用户界面",


### PR DESCRIPTION
### Problem

Deleting a folder in the *Devices* list is recursive — `delObjects(id, true)` removes the folder **and every device and state inside it**. But the confirmation only said *"Folder will be deleted. Are you sure?"*, hiding that the contents go with it. On top of that, the *"Do not show dialog for 5 minutes"* checkbox suppressed the dialog for folders too, so within that window a folder (and its whole contents) could be deleted **without any confirmation at all** — the delete was even triggered from a `setTimeout` inside `render()`.

The device confirmation is fine (*"Device and all states will be deleted"* — honest, and a single device is a small, opt-in operation). The risk is specific to recursive **folder** deletion.

### Change

- **Honest text:** the folder confirmation now reads *"Folder and all its devices and states will be deleted. Are you sure?"* (translated in all 11 languages).
- **No suppression for folders:** the *"Do not show for 5 minutes"* option now applies to single devices only; recursive folder deletion **always** asks. The checkbox is hidden in the folder dialog.

As a side effect the render-time `setTimeout` delete no longer runs for folders (they always go through the dialog); it remains only for the guarded single-device path.

### Verified

- `src-admin` `tsc` (typecheck) and `eslint` both pass.
- No other code path used the old string; the new string is wired through `I18n.t`.
