### PR TITLE
Prevent a crash when saving a device with a not-yet-cached state

### DIFF
--- a/src-admin/src/Dialogs/DialogEditDevice.tsx
+++ b/src-admin/src/Dialogs/DialogEditDevice.tsx
@@ -945,7 +945,12 @@ class DialogEditDevice extends React.Component<DialogEditDeviceProps, DialogEdit
         const array = this.state.addedStates.filter(item => Object.keys(this.state.ids).includes(item.name));
         for (let i = 0; i < array.length; i++) {
             const item = array[i];
-            const stateObj = this.props.objects[item.id];
+            const stateObj = this.props.objects[item.id] as ioBroker.Object | undefined;
+            if (!stateObj) {
+                // The object may not be in the cache yet (e.g. a freshly created/mapped state);
+                // skip it instead of crashing on `stateObj.common` below.
+                continue;
+            }
             stateObj.common ||= {} as ioBroker.StateCommon;
             stateObj.common.alias ||= {};
             stateObj.common.alias.id = this.state.ids[item.name];


### PR DESCRIPTION
### Problem

`DialogEditDevice.updateNewState()` reads the object of each added state from the props cache and writes to it right away:

```ts
const stateObj = this.props.objects[item.id];
stateObj.common ||= {} as ioBroker.StateCommon;   // TypeError if stateObj is undefined
```

`props.objects` is a `Record<string, ioBroker.Object>`, so the index access is typed as always present — but at runtime it can be missing (e.g. a freshly created/mapped state whose debounced cache update has not arrived yet). Accessing `stateObj.common` then throws a `TypeError` and aborts the whole save.

### Change

Guard against the missing object and skip that entry instead of crashing (typed via an explicit `| undefined` cast so the check isn't flagged as unnecessary).

### Verified

- `src-admin` `tsc` (typecheck) and `eslint` both pass.
