### PR TITLE
Show a message when a drag-and-drop move is blocked by a name collision

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -2542,13 +2542,19 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                 targetPath = `${parentId}.${lastPart}`;
             }
 
-            // Validate drop target
+            // Structural targets cannot receive a drop — reject them silently (they are already
+            // marked red while dragging).
             if (
                 !dropTarget.id?.includes('alias.0') ||
                 dropTarget.id?.includes('automatically_detected') ||
-                dropTarget.id?.includes('linked_devices') ||
-                this.objects[targetPath]
+                dropTarget.id?.includes('linked_devices')
             ) {
+                return;
+            }
+            // The target looks droppable, but an object with this name already exists there — tell
+            // the user instead of silently doing nothing.
+            if (this.objects[targetPath]) {
+                this.setState({ message: I18n.t('An object with this name already exists in the target folder') });
                 return;
             }
 

--- a/src-admin/src/i18n/de.json
+++ b/src-admin/src/i18n/de.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Ein Objekt mit diesem Namen existiert bereits im Zielordner",
     "Add": "Hinzufügen",
     "Add new folder to \"%s\"": "Neuen Ordner zu \"%s\" hinzufügen",
     "Add state": "Zustand hinzufügen",

--- a/src-admin/src/i18n/en.json
+++ b/src-admin/src/i18n/en.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "An object with this name already exists in the target folder",
     "Add": "Add",
     "Add new folder to \"%s\"": "Add new folder to \"%s\"",
     "Add state": "Add state",

--- a/src-admin/src/i18n/es.json
+++ b/src-admin/src/i18n/es.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Ya existe un objeto con este nombre en la carpeta de destino",
     "Add": "Añadir",
     "Add new folder to \"%s\"": "Agregar nueva carpeta a \"%s\"",
     "Add state": "Agregar estado",

--- a/src-admin/src/i18n/fr.json
+++ b/src-admin/src/i18n/fr.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Un objet portant ce nom existe déjà dans le dossier cible",
     "Add": "Ajouter",
     "Add new folder to \"%s\"": "Ajouter un nouveau dossier à \"%s\"",
     "Add state": "Ajouter un état",

--- a/src-admin/src/i18n/it.json
+++ b/src-admin/src/i18n/it.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Esiste già un oggetto con questo nome nella cartella di destinazione",
     "Add": "Inserisci",
     "Add new folder to \"%s\"": "Aggiungi nuova cartella a \"%s\"",
     "Add state": "Aggiungi stato",

--- a/src-admin/src/i18n/nl.json
+++ b/src-admin/src/i18n/nl.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Er bestaat al een object met deze naam in de doelmap",
     "Add": "Toevoegen",
     "Add new folder to \"%s\"": "Nieuwe map toevoegen aan \"%s\"",
     "Add state": "Staat toevoegen",

--- a/src-admin/src/i18n/pl.json
+++ b/src-admin/src/i18n/pl.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Obiekt o tej nazwie już istnieje w folderze docelowym",
     "Add": "Dodaj",
     "Add new folder to \"%s\"": "Dodaj nowy folder do „%s”",
     "Add state": "Dodaj stan",

--- a/src-admin/src/i18n/pt.json
+++ b/src-admin/src/i18n/pt.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Já existe um objeto com este nome na pasta de destino",
     "Add": "Adicionar",
     "Add new folder to \"%s\"": "Adicione nova pasta a \"%s\"",
     "Add state": "Adicionar estado",

--- a/src-admin/src/i18n/ru.json
+++ b/src-admin/src/i18n/ru.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Объект с таким именем уже существует в целевой папке",
     "Add": "Добавить",
     "Add new folder to \"%s\"": "Добавить новую папку в \"%s\"",
     "Add state": "Добавить состояние",

--- a/src-admin/src/i18n/uk.json
+++ b/src-admin/src/i18n/uk.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "Об'єкт з таким іменем вже існує в цільовій папці",
     "Add": "додати",
     "Add new folder to \"%s\"": "Додати нову папку до \"%s\"",
     "Add state": "Додати стан",

--- a/src-admin/src/i18n/zh-cn.json
+++ b/src-admin/src/i18n/zh-cn.json
@@ -1,4 +1,5 @@
 {
+    "An object with this name already exists in the target folder": "目标文件夹中已存在同名对象",
     "Add": "添加",
     "Add new folder to \"%s\"": "将新文件夹添加到“%s”",
     "Add state": "添加状态",


### PR DESCRIPTION
### Problem

Dragging a device onto a target where an object with the same name already exists is rejected, but `handleDragEnd` returned silently. The row is marked red while dragging, yet on release nothing happens and there is no explanation — which reads as *"the move just doesn't work"*.

### Change

On a name collision, show a short message (*"An object with this name already exists in the target folder"*, translated in all 11 languages) instead of returning silently. Structurally invalid targets (non-`alias.0`, `automatically_detected`, `linked_devices`) keep the silent reject — they cannot receive a drop and are already marked red.

### Verified

- `src-admin` `tsc` (typecheck) and `eslint` both pass.
