### PR TITLE
fix(widgets): stop printing a tile's value twice on the wide layouts

### DIFF
--- a/src-admin/src/WidgetsManager/Widgets/AirCondition.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/AirCondition.tsx
@@ -1197,8 +1197,10 @@ export class WidgetAirCondition extends WidgetGeneric<WidgetAirConditionState> {
     }
 
     protected renderTileStatus(): React.JSX.Element | null {
+        // Every layout but the 1x1 shows the same content through renderTileAction — rendering it
+        // here as well printed it twice on one tile.
         const size = this.props.settings?.size || '1x1';
-        if (size === '2x0.5') {
+        if (size !== '1x1') {
             return null;
         }
 

--- a/src-admin/src/WidgetsManager/Widgets/Motion.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Motion.tsx
@@ -188,9 +188,10 @@ export class WidgetMotion extends WidgetGeneric<WidgetMotionState, AlarmWidgetSe
     }
 
     protected renderTileStatus(): React.JSX.Element | null {
+        // Every layout but the 1x1 shows the same content through renderTileAction — rendering it
+        // here as well printed it twice on one tile.
         const size = this.props.settings?.size || '1x1';
-        if (size === '2x0.5' || size === '2x1') {
-            // 2x0.5 has no status row; 2x1 already shows motion text + brightness in renderTileAction
+        if (size !== '1x1') {
             return null;
         }
 

--- a/src-admin/src/WidgetsManager/Widgets/Thermostat.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Thermostat.tsx
@@ -755,8 +755,10 @@ export class WidgetThermostat extends WidgetGeneric<WidgetThermostatState> {
     }
 
     protected renderTileStatus(): React.JSX.Element | null {
+        // Every layout but the 1x1 shows the same content through renderTileAction — rendering it
+        // here as well printed it twice on one tile.
         const size = this.props.settings?.size || '1x1';
-        if (size === '2x0.5') {
+        if (size !== '1x1') {
             return null;
         }
 


### PR DESCRIPTION
Three widgets print the same content twice on one tile at the 2x1 and 2x2 sizes.

`WidgetGeneric.renderWideTall()` — which `renderHuge()` delegates to — renders **both** the status
slot and the action slot:

```
renderWideTall()
  ├── name
  ├── renderTileStatus()   ← small, under the name
  └── renderTileAction()   ← large, right-hand column
```

A widget whose action row repeats what its status row says therefore shows it twice. `Humidity` and
`Temperature` guard their status row with `size !== '1x1'` and are fine; the affected widgets guard
with `size === '2x0.5'`, which only covers the one layout that has no status row at all.

| widget | duplicated | sizes |
| --- | --- | --- |
| `Thermostat` | setpoint, actual temperature, humidity, mode icon | 2x1, 2x2 |
| `AirCondition` | setpoint, actual temperature, humidity, fan speed, mode icon | 2x1, 2x2 |
| `Motion` | motion text, brightness, last-motion time | 2x2 only |

`Motion` is the one that shows this is a copy-paste rather than a design: its guard already excluded
2x1 with the comment *"2x1 already shows motion text + brightness in renderTileAction"*, so the
duplication was known and fixed at one size and missed at the other.

Both climate action rows render everything their status rows do — humidity included, which was the one
thing worth checking before suppressing the status row — so nothing is lost.

**Deliberately untouched:** `MediaPlayer` and `Location` keep their `2x0.5` tests. Both override
`renderCompact`/`renderWideTall` completely instead of using the status/action slots (`MediaPlayer`'s
`renderTileAction()` returns an empty `<Box />`), so neither ever duplicated anything, and forcing the
same guard on them would have deleted the track title from a wide media tile.

The same bug in `Illuminance`, `Window`, `FireAlarm`, `FloodAlarm` and `Warning` is fixed in #665.
Between the two PRs the class is closed — no widget using the generic layout guards this the old way
any more.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, `test:unit` (77).
Touches no file that #665 touches, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
