### PR TITLE
feat(widgets): control tiles for fan and airPurifier

### DIFF
--- a/src-admin/src/WidgetsManager/Category.tsx
+++ b/src-admin/src/WidgetsManager/Category.tsx
@@ -61,6 +61,7 @@ import {
     WidgetSwitch,
     WidgetLight,
     WidgetDimmer,
+    WidgetFan,
     WidgetTemperature,
     WidgetMotion,
     WidgetWindow,
@@ -70,6 +71,7 @@ import {
     WidgetButtonSensor,
     WidgetCamera,
     WidgetAirCondition,
+    WidgetAirPurifier,
     WidgetWarning,
     WidgetLock,
     WidgetCoAlarm,
@@ -2250,6 +2252,10 @@ export default class Category extends Component<CategoryProps, CategoryState> {
             Widget = WidgetThermostat;
         } else if (type === Types.airCondition) {
             Widget = WidgetAirCondition;
+        } else if (type === Types.fan) {
+            Widget = WidgetFan;
+        } else if (type === Types.airPurifier) {
+            Widget = WidgetAirPurifier;
         } else if (type === Types.warning) {
             Widget = WidgetWarning;
         } else if (type === Types.volume || type === Types.volumeGroup) {

--- a/src-admin/src/WidgetsManager/Widgets/AirPurifier.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/AirPurifier.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { ConfigItemPanel } from '@iobroker/json-config';
+import { FilterAlt } from '@mui/icons-material';
+
+import { WidgetFanBase } from './FanBase';
+
+export class WidgetAirPurifier extends WidgetFanBase {
+    static override getConfigSchema(): { name: string; schema: ConfigItemPanel } {
+        return {
+            name: 'wm_Air purifier',
+            schema: {
+                type: 'panel',
+                items: {},
+            },
+        };
+    }
+
+    protected renderTypeIcon(): React.JSX.Element {
+        return <FilterAlt sx={{ color: this.isPoweredOff() ? 'text.disabled' : '#66bb6a' }} />;
+    }
+}
+
+export default WidgetAirPurifier;

--- a/src-admin/src/WidgetsManager/Widgets/Fan.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Fan.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { ConfigItemPanel } from '@iobroker/json-config';
+import { Air } from '@mui/icons-material';
+
+import { WidgetFanBase } from './FanBase';
+
+export class WidgetFan extends WidgetFanBase {
+    static override getConfigSchema(): { name: string; schema: ConfigItemPanel } {
+        return {
+            name: 'wm_Fan',
+            schema: {
+                type: 'panel',
+                items: {},
+            },
+        };
+    }
+
+    protected renderTypeIcon(): React.JSX.Element {
+        return <Air sx={{ color: this.isPoweredOff() ? 'text.disabled' : '#4fc3f7' }} />;
+    }
+}
+
+export default WidgetFan;

--- a/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
@@ -1,0 +1,925 @@
+import React from 'react';
+import { Box, Button, Dialog, DialogContent, IconButton, Slider, TextField, Tooltip, Typography } from '@mui/material';
+import { Air, Close, PowerSettingsNew, SwapHoriz, SwapVert } from '@mui/icons-material';
+import { I18n } from '@iobroker/gui-components';
+
+import WidgetGeneric, { toNumberOrNull, type WidgetGenericProps, type WidgetGenericState } from './Generic';
+import { parseCommonStates, stateKeyToValue } from './commonStates';
+import { clampToRange, type SetpointRange as NumericRange } from './climate';
+
+/**
+ * A device-declared numeric range, trusted only once both bounds are explicit.
+ *
+ * A datapoint that declares neither bound has said nothing about its scale, and inventing one caps
+ * every write on a device whose native range is wider — an rpm speed pinned to 0–100.
+ */
+function explicitRangeFromCommon(common: ioBroker.StateCommon | undefined): NumericRange | null {
+    if (!common || common.min == null || common.max == null) {
+        return null;
+    }
+    const min = Number(common.min);
+    const max = Number(common.max);
+    const step = common.step != null ? Number(common.step) : 1;
+    if (isNaN(min) || isNaN(max) || max <= min) {
+        return null;
+    }
+    return { min, max, step: step > 0 ? step : 1 };
+}
+
+/**
+ * Control surface shared by `fan` and `airPurifier`: both declare the identical SPEED / POWER /
+ * SPEED_LEVEL / SWING / AIRFLOW_DIRECTION states (verified against the installed type-detector).
+ * `airPurifier` adds only a filter reading, which `WidgetGeneric`'s "i" dialog already renders via
+ * `EXTRA_INFO_NAMES` — nothing filter-specific belongs here.
+ */
+export interface WidgetFanBaseState extends WidgetGenericState {
+    power: boolean | number | null;
+    speed: string | number | null;
+    speedStates: Record<string, string>;
+    /** Fallback scale for a SPEED datapoint that declares no `common.states` of its own */
+    speedRange: NumericRange | null;
+    /** What the user has typed into the last-resort speed field but not committed yet */
+    speedDraft: string | null;
+    speedLevel: number | null;
+    speedLevelRange: NumericRange;
+    speedLevelUnit: string;
+    swing: string | number | boolean | null;
+    swingStates: Record<string, string>;
+    swingIsBoolean: boolean;
+    airflow: string | number | null;
+    airflowStates: Record<string, string>;
+    dialogOpen: boolean;
+}
+
+export abstract class WidgetFanBase extends WidgetGeneric<WidgetFanBaseState> {
+    private readonly powerId: string | null;
+    private readonly speedId: string | null;
+    private readonly speedLevelId: string | null;
+    private readonly swingId: string | null;
+    private readonly airflowId: string | null;
+    /** `common.type` of the power datapoint — POWER is `boolean|number`, and the write must match it */
+    private powerIsNumber = false;
+    /**
+     * Whether that type is known yet.
+     *
+     * Until it is, the widget cannot tell a `boolean` datapoint from a `number` one, and writing the
+     * wrong one is a write the device may reject. The control stays disabled rather than guessing.
+     */
+    private powerTypeKnown = false;
+    private readonly patternSpeedStates: Record<string, string>;
+    private readonly patternSwingStates: Record<string, string>;
+    private readonly patternAirflowStates: Record<string, string>;
+    /**
+     * `common.type` behind a SWING value list — a boolean datapoint that ships its own two labels
+     * still needs a boolean write, not the string `stateKeyToValue` produces for a non-numeric key.
+     */
+    private swingListIsBoolean = false;
+    /** Held while a slider drag is in progress, so the device's own echo cannot fight the pointer */
+    private speedDragging = false;
+    private speedLevelDragging = false;
+
+    /**
+     * The value list the *pattern* declares for a state, as a label map.
+     *
+     * `statesDefined` — the flag saying whether a device must use these values — is stripped before
+     * the widget sees the state, so this is a fallback for a datapoint that declares nothing, never an
+     * override of one that does.
+     *
+     * @param state The detected state, if the device has it
+     * @returns Value → label, empty when the pattern declares no list
+     */
+    private static patternStates(
+        state: { defaultStates?: Record<string, string> } | undefined,
+    ): Record<string, string> {
+        return state?.defaultStates ? parseCommonStates(state.defaultStates) : {};
+    }
+
+    constructor(props: WidgetGenericProps) {
+        super(props);
+        const states = props.widget.control.states;
+        this.powerId = states.find(s => s.name === 'POWER' && s.id)?.id ?? null;
+        this.speedId = states.find(s => s.name === 'SPEED' && s.id)?.id ?? null;
+        const speedLevelState = states.find(s => s.name === 'SPEED_LEVEL' && s.id);
+        this.speedLevelId = speedLevelState?.id ?? null;
+        // SWING is declared twice — a numeric `level.mode.swing` list, then a boolean
+        // `switch.mode.swing` toggle. The backend drops any entry whose pattern went unmatched before
+        // `control.states` reaches the widget, so normally only one of the two survives; a device that
+        // genuinely offers both keeps two real ids, and — entries keeping pattern-declaration order —
+        // the numeric one is found first, so the richer list wins over the plain toggle.
+        const swingState = states.find(s => s.name === 'SWING' && s.id);
+        this.swingId = swingState?.id ?? null;
+        const airflowState = states.find(s => s.name === 'AIRFLOW_DIRECTION' && s.id);
+        this.airflowId = airflowState?.id ?? null;
+        // A datapoint is not obliged to declare `common.states`, and a value list with no entries is
+        // no control at all. The pattern's own labels are what these values mean, so they stand in for
+        // a datapoint that declares none — applied once the object has been read, never before, since
+        // a boolean SWING can take none of them.
+        this.patternSpeedStates = WidgetFanBase.patternStates(states.find(s => s.name === 'SPEED' && s.id));
+        this.patternSwingStates = WidgetFanBase.patternStates(swingState);
+        this.patternAirflowStates = WidgetFanBase.patternStates(airflowState);
+
+        this.state = {
+            ...this.state,
+            power: null,
+            speed: null,
+            speedStates: {},
+            speedRange: null,
+            speedDraft: null,
+            speedLevel: null,
+            speedLevelRange: { min: 0, max: 100, step: 1 },
+            // The backend fills `unit` on the detected state itself, so the widget can show it before
+            // the datapoint's object has even been fetched. Left blank rather than defaulted to '%':
+            // the pattern's defaultUnit is only a suggestion, and printing one the device never
+            // reported would state something it never said.
+            speedLevelUnit: speedLevelState?.unit || '',
+            swing: null,
+            swingStates: {},
+            swingIsBoolean: false,
+            airflow: null,
+            airflowStates: {},
+            dialogOpen: false,
+        };
+    }
+
+    componentDidMount(): void {
+        super.componentDidMount();
+        if (this.powerId) {
+            this.props.stateContext.getState(this.powerId, this.onPowerChange);
+            void this.loadPowerType();
+        }
+        if (this.speedId) {
+            this.props.stateContext.getState(this.speedId, this.onSpeedChange);
+            void this.loadSpeedMeta();
+        }
+        if (this.speedLevelId) {
+            this.props.stateContext.getState(this.speedLevelId, this.onSpeedLevelChange);
+            void this.loadSpeedLevelRange();
+        }
+        if (this.swingId) {
+            this.props.stateContext.getState(this.swingId, this.onSwingChange);
+            void this.loadSwingObject();
+        }
+        if (this.airflowId) {
+            this.props.stateContext.getState(this.airflowId, this.onAirflowChange);
+            void this.loadAirflowStates();
+        }
+    }
+
+    componentWillUnmount(): void {
+        super.componentWillUnmount();
+        if (this.powerId) {
+            this.props.stateContext.removeState(this.powerId, this.onPowerChange);
+        }
+        if (this.speedId) {
+            this.props.stateContext.removeState(this.speedId, this.onSpeedChange);
+        }
+        if (this.speedLevelId) {
+            this.props.stateContext.removeState(this.speedLevelId, this.onSpeedLevelChange);
+        }
+        if (this.swingId) {
+            this.props.stateContext.removeState(this.swingId, this.onSwingChange);
+        }
+        if (this.airflowId) {
+            this.props.stateContext.removeState(this.airflowId, this.onAirflowChange);
+        }
+    }
+
+    private async loadPowerType(): Promise<void> {
+        if (!this.powerId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.powerId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            if (obj?.common?.type === 'number' || obj?.common?.type === 'boolean') {
+                this.powerIsNumber = obj.common.type === 'number';
+                this.powerTypeKnown = true;
+                this.forceUpdate();
+            }
+        } catch {
+            // Unreadable object: `onPowerChange` still infers the type from the first live value
+        }
+    }
+
+    private async loadAirflowStates(): Promise<void> {
+        if (!this.airflowId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.airflowId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            const parsed = parseCommonStates(obj?.common?.states);
+            this.setState({ airflowStates: Object.keys(parsed).length ? parsed : this.patternAirflowStates });
+        } catch {
+            this.setState({ airflowStates: this.patternAirflowStates });
+        }
+    }
+
+    /**
+     * SPEED is the one state both patterns require, so it must stay controllable even when the
+     * datapoint declares neither a value list nor a range: falling back to a plain number field keeps
+     * it writable instead of leaving the device's only mandatory control unreachable.
+     */
+    private async loadSpeedMeta(): Promise<void> {
+        if (!this.speedId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.speedId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            const parsed = parseCommonStates(obj?.common?.states);
+            if (Object.keys(parsed).length) {
+                this.setState({ speedStates: parsed });
+                return;
+            }
+            // A declared range beats the pattern's labels: it is this device's own statement about
+            // what the datapoint accepts, where the labels are only what the pattern expects.
+            const range = explicitRangeFromCommon(obj?.common);
+            if (range) {
+                this.setState({ speedRange: range });
+                return;
+            }
+            this.setState({ speedStates: this.patternSpeedStates });
+        } catch {
+            this.setState({ speedStates: this.patternSpeedStates });
+        }
+    }
+
+    private async loadSpeedLevelRange(): Promise<void> {
+        if (!this.speedLevelId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.speedLevelId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            const range = explicitRangeFromCommon(obj?.common);
+            if (range) {
+                this.setState({ speedLevelRange: range });
+            }
+        } catch {
+            // ignore
+        }
+    }
+
+    private async loadSwingObject(): Promise<void> {
+        if (!this.swingId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.swingId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            if (obj?.common) {
+                const parsed = parseCommonStates(obj.common.states);
+                // A boolean datapoint that ships its own two labels is still a list, not a switch
+                const isBoolean = obj.common.type === 'boolean' && !Object.keys(parsed).length;
+                this.swingListIsBoolean = obj.common.type === 'boolean';
+                this.setState({ swingIsBoolean: isBoolean });
+                if (isBoolean) {
+                    // A toggle, so the pattern's four-way list would offer values it cannot take
+                    this.setState({ swingStates: {} });
+                } else {
+                    this.setState({ swingStates: Object.keys(parsed).length ? parsed : this.patternSwingStates });
+                }
+            }
+        } catch {
+            // Unreadable object: the pattern's labels are all the widget knows, and they beat no control
+            this.setState({ swingStates: this.patternSwingStates });
+        }
+    }
+
+    // --- State change handlers ---
+
+    private onPowerChange = (_id: string, state: ioBroker.State): void => {
+        const val = state.val;
+        // The live value is the surest signal of the datapoint's actual type — a `getObject()` that
+        // fails or hasn't resolved yet must not leave a numeric POWER datapoint written as a boolean.
+        if (typeof val === 'number' || typeof val === 'boolean') {
+            this.powerIsNumber = typeof val === 'number';
+            this.powerTypeKnown = true;
+        }
+        const power = typeof val === 'number' || typeof val === 'boolean' ? val : null;
+        if (power !== this.state.power) {
+            this.setState({ power });
+        }
+    };
+
+    private onSpeedChange = (_id: string, state: ioBroker.State): void => {
+        if (this.speedDragging) {
+            return;
+        }
+        const val = state.val;
+        const speed = typeof val === 'number' || typeof val === 'string' ? val : null;
+        if (speed !== this.state.speed) {
+            this.setState({ speed });
+        }
+    };
+
+    private onSpeedLevelChange = (_id: string, state: ioBroker.State): void => {
+        if (this.speedLevelDragging) {
+            return;
+        }
+        const speedLevel = toNumberOrNull(state.val);
+        if (speedLevel !== this.state.speedLevel) {
+            this.setState({ speedLevel });
+        }
+    };
+
+    private onSwingChange = (_id: string, state: ioBroker.State): void => {
+        const val = state.val;
+        const swing = typeof val === 'number' || typeof val === 'boolean' || typeof val === 'string' ? val : null;
+        if (swing !== this.state.swing) {
+            this.setState({ swing });
+        }
+    };
+
+    private onAirflowChange = (_id: string, state: ioBroker.State): void => {
+        const val = state.val;
+        const airflow = typeof val === 'number' || typeof val === 'string' ? val : null;
+        if (airflow !== this.state.airflow) {
+            this.setState({ airflow });
+        }
+    };
+
+    // --- Actions ---
+    //
+    // None of these update state optimistically: the subscription above reports what the device
+    // actually accepted, and a rejected write must not leave a control showing a value the device
+    // never took. The SPEED range-fallback slider and the SPEED_LEVEL slider are the exception during
+    // an active drag — they must track the pointer — which is why each carries its own dragging guard.
+
+    /**
+     * POWER is `boolean|number` in the pattern, so the write has to match the datapoint. Refuses while
+     * the type is unknown rather than writing a value the device would reject.
+     */
+    private togglePower = (): void => {
+        if (!this.powerId || !this.powerTypeKnown) {
+            return;
+        }
+        const isOn = !!this.state.power;
+        const next: boolean | number = this.powerIsNumber ? (isOn ? 0 : 1) : !isOn;
+        void this.setValue(this.powerId, next);
+    };
+
+    private setSpeed = (value: string | number): void => {
+        if (this.speedId) {
+            void this.setValue(this.speedId, value);
+        }
+    };
+
+    private commitSpeedDraft(): void {
+        const draft = this.state.speedDraft;
+        if (draft === null) {
+            return;
+        }
+        this.setState({ speedDraft: null });
+        if (draft.trim() === '') {
+            return;
+        }
+        const value = Number(draft.replace(',', '.'));
+        if (!isNaN(value)) {
+            this.setSpeed(value);
+        }
+    }
+
+    private setSpeedLevel = (value: number): void => {
+        if (this.speedLevelId) {
+            void this.setValue(this.speedLevelId, clampToRange(value, this.state.speedLevelRange));
+        }
+    };
+
+    private setSwing = (value: string | number | boolean): void => {
+        if (this.swingId) {
+            void this.setValue(this.swingId, value);
+        }
+    };
+
+    private setAirflow = (value: string | number): void => {
+        if (this.airflowId) {
+            void this.setValue(this.airflowId, value);
+        }
+    };
+
+    /**
+     * A list entry's key, as `stateKeyToValue` reads it — coerced for a boolean datapoint that ships
+     * its own labels.
+     *
+     * Only `0`/`1` and `false`/`true` carry a meaning a boolean datapoint can take. Any other key
+     * (`{"Off":"Off","On":"On"}`) says nothing about which of the two it is, and mapping the
+     * unrecognised ones all to `false` would leave the second option unreachable — so the list keeps
+     * its own keys and the datapoint decides.
+     *
+     * @param key Key from the value list
+     * @param keys Every key in that list, in order
+     * @returns The value to write
+     */
+    private swingListValue(key: string, keys: string[]): string | number | boolean {
+        const value = stateKeyToValue(key);
+        if (!this.swingListIsBoolean) {
+            return value;
+        }
+        if (typeof value === 'number') {
+            return value !== 0;
+        }
+        const lower = value.toLowerCase();
+        if (lower === 'true' || lower === 'false') {
+            return lower === 'true';
+        }
+        // Exactly two unrecognised keys on a boolean datapoint can only be off then on, in order
+        return keys.length === 2 ? keys.indexOf(key) === 1 : value;
+    }
+
+    // --- Label helpers (mirror WidgetAirCondition's fan-related label maps; kept separate since
+    // AirCondition.tsx is out of scope for this change — shared only between Fan and AirPurifier) ---
+
+    private static readonly SPEED_MAP: Record<string, string> = {
+        auto: 'wm_speed_auto',
+        high: 'wm_speed_high',
+        low: 'wm_speed_low',
+        medium: 'wm_speed_medium',
+        quiet: 'wm_speed_quiet',
+        turbo: 'wm_speed_turbo',
+    };
+
+    private static getSpeedLabel(label: string): string {
+        const key = WidgetFanBase.SPEED_MAP[label.toLowerCase().trim()];
+        return key ? I18n.t(key) : label;
+    }
+
+    private static readonly SWING_MAP: Record<string, string> = {
+        auto: 'wm_swing_auto',
+        horizontal: 'wm_swing_horizontal',
+        stationary: 'wm_swing_stationary',
+        vertical: 'wm_swing_vertical',
+    };
+
+    private static getSwingLabel(label: string): string {
+        const key = WidgetFanBase.SWING_MAP[label.toLowerCase().trim()];
+        return key ? I18n.t(key) : label;
+    }
+
+    private static readonly AIRFLOW_MAP: Record<string, string> = {
+        forward: 'wm_airflow_forward',
+        reverse: 'wm_airflow_reverse',
+    };
+
+    private static getAirflowLabel(label: string): string {
+        const key = WidgetFanBase.AIRFLOW_MAP[label.toLowerCase().trim()];
+        return key ? I18n.t(key) : label;
+    }
+
+    private getCurrentSpeedLabel(): string | null {
+        const { speed, speedStates } = this.state;
+        if (speed == null) {
+            return null;
+        }
+        return speedStates[String(speed)] || null;
+    }
+
+    /** True once the device is known to be off — not merely "hasn't reported power yet" */
+    protected isPoweredOff(): boolean {
+        return !!this.powerId && this.state.power != null && !this.state.power;
+    }
+
+    // --- Tile overrides ---
+
+    protected isTileActive(): boolean {
+        return !this.isPoweredOff() && (this.state.speed != null || this.state.speedLevel != null);
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    protected hasTileAction(): boolean {
+        return true;
+    }
+
+    protected onTileClick(): void {
+        this.setState({ dialogOpen: true });
+    }
+
+    /** Default icon for the device type; overridden per subclass, used when no custom icon is set */
+    protected abstract renderTypeIcon(): React.JSX.Element;
+
+    protected renderTileIcon(): React.JSX.Element {
+        return this.renderBaseIcon() ?? this.renderTypeIcon();
+    }
+
+    /**
+     * Compact tile shows this only at 1x1; every other size shows {@link renderTileAction} instead,
+     * which renders the same information — showing both at once would print it twice on one tile.
+     */
+    protected renderTileStatus(): React.JSX.Element | null {
+        const size = this.props.settings?.size || '1x1';
+        if (size !== '1x1') {
+            return null;
+        }
+        return this.renderStatusContent('caption');
+    }
+
+    protected renderTileAction(): React.JSX.Element | null {
+        return this.renderStatusContent('body2');
+    }
+
+    private renderStatusContent(variant: 'caption' | 'body2'): React.JSX.Element | null {
+        const { speedLevel, speedLevelUnit } = this.state;
+        const speedLabel = this.getCurrentSpeedLabel();
+        const speedNumeric = typeof this.state.speed === 'number' ? this.state.speed : null;
+        const speedText = speedLabel
+            ? WidgetFanBase.getSpeedLabel(speedLabel)
+            : speedNumeric != null
+              ? String(Math.round(speedNumeric))
+              : null;
+        const poweredOff = this.isPoweredOff();
+        const hasAnyReading = poweredOff || speedText != null || speedLevel != null;
+        const iconSize = variant === 'caption' ? 12 : 14;
+
+        if (!hasAnyReading) {
+            return (
+                <Typography
+                    variant={variant}
+                    sx={{ color: 'text.disabled' }}
+                >
+                    {I18n.t('wm_No data')}
+                </Typography>
+            );
+        }
+
+        return (
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    {poweredOff ? (
+                        <Tooltip title={I18n.t('wm_On/Off')}>
+                            <PowerSettingsNew sx={{ fontSize: iconSize + 2, color: 'text.disabled' }} />
+                        </Tooltip>
+                    ) : null}
+                    {speedText ? (
+                        <Typography
+                            variant={variant}
+                            sx={{
+                                fontWeight: 500,
+                                color: 'text.secondary',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '2px',
+                            }}
+                        >
+                            <Air sx={{ fontSize: iconSize, verticalAlign: 'middle' }} />
+                            {speedText}
+                        </Typography>
+                    ) : null}
+                </Box>
+                {speedLevel != null ? (
+                    <Typography
+                        variant={variant}
+                        sx={{ color: 'text.secondary' }}
+                    >
+                        {Math.round(speedLevel)}
+                        {speedLevelUnit ? ` ${speedLevelUnit}` : ''}
+                    </Typography>
+                ) : null}
+            </Box>
+        );
+    }
+
+    protected getHistoryIds(): { id: string; color: string }[] {
+        return this.speedLevelId ? [{ id: this.speedLevelId, color: '#4fc3f7' }] : [];
+    }
+
+    protected getChartUnit(): string | undefined {
+        return this.speedLevelId ? this.state.speedLevelUnit : undefined;
+    }
+
+    // --- Control dialog ---
+
+    /**
+     * SPEED, in whichever shape the datapoint actually offers: a labelled list, a declared numeric
+     * range, or — lacking both — a plain number field, so the one required control is never dropped.
+     */
+    private renderSpeedControl(dimmedSx: Record<string, unknown>): React.JSX.Element | null {
+        if (!this.speedId) {
+            return null;
+        }
+        const { speed, speedStates, speedRange, speedDraft } = this.state;
+        const speedEntries = Object.entries(speedStates);
+
+        return (
+            <Box sx={{ mb: 2 }}>
+                <Typography
+                    variant="body2"
+                    sx={{ fontWeight: 600, mb: 0.75, color: 'text.secondary' }}
+                >
+                    <Air sx={{ fontSize: 16, verticalAlign: 'middle', mr: 0.5 }} />
+                    {I18n.t('wm_Speed')}
+                </Typography>
+                {speedEntries.length > 0 ? (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.75,
+                            justifyContent: 'center',
+                            flexWrap: 'wrap',
+                            ...dimmedSx,
+                        }}
+                    >
+                        {speedEntries.map(([key, label]) => {
+                            const value = stateKeyToValue(key);
+                            const isActive = speed != null && String(speed) === key;
+                            return (
+                                <Button
+                                    key={key}
+                                    variant={isActive ? 'contained' : 'outlined'}
+                                    color={isActive ? 'primary' : 'inherit'}
+                                    disabled={this.isReadOnly}
+                                    onClick={() => this.setSpeed(value)}
+                                    size="small"
+                                    sx={{ textTransform: 'none', borderRadius: '20px', minWidth: 0, px: 1.5 }}
+                                >
+                                    {WidgetFanBase.getSpeedLabel(label)}
+                                </Button>
+                            );
+                        })}
+                    </Box>
+                ) : speedRange ? (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, ...dimmedSx }}>
+                        <Slider
+                            disabled={this.isReadOnly}
+                            value={typeof speed === 'number' ? speed : speedRange.min}
+                            min={speedRange.min}
+                            max={speedRange.max}
+                            step={speedRange.step}
+                            valueLabelDisplay="auto"
+                            onChange={(_e, value) => {
+                                if (!Array.isArray(value)) {
+                                    this.speedDragging = true;
+                                    this.setState({ speed: value });
+                                }
+                            }}
+                            onChangeCommitted={(_e, value) => {
+                                this.speedDragging = false;
+                                if (!Array.isArray(value)) {
+                                    this.setSpeed(value);
+                                }
+                            }}
+                            sx={{ flex: 1 }}
+                        />
+                    </Box>
+                ) : (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', ...dimmedSx }}>
+                        <TextField
+                            variant="standard"
+                            type="number"
+                            size="small"
+                            disabled={this.isReadOnly}
+                            value={speedDraft ?? (typeof speed === 'number' ? speed : '')}
+                            onChange={e => this.setState({ speedDraft: e.target.value })}
+                            onBlur={() => this.commitSpeedDraft()}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') {
+                                    this.commitSpeedDraft();
+                                }
+                            }}
+                            slotProps={{ htmlInput: { style: { textAlign: 'right', width: 80 } } }}
+                        />
+                    </Box>
+                )}
+            </Box>
+        );
+    }
+
+    private renderControlDialog(): React.JSX.Element | null {
+        if (!this.state.dialogOpen) {
+            return null;
+        }
+
+        const {
+            name,
+            power,
+            speedLevel,
+            speedLevelRange,
+            speedLevelUnit,
+            swing,
+            swingStates,
+            swingIsBoolean,
+            airflow,
+            airflowStates,
+        } = this.state;
+        const airflowEntries = Object.entries(airflowStates);
+        const swingEntries = Object.entries(swingStates);
+        const swingKeys = swingEntries.map(([key]) => key);
+        const dimmedSx = this.isPoweredOff() ? { opacity: 0.5, transition: 'opacity 0.25s ease' } : {};
+
+        return (
+            <Dialog
+                open
+                onClose={() => this.setState({ dialogOpen: false })}
+                maxWidth="xs"
+                fullWidth
+                slotProps={{ paper: { sx: { borderRadius: '24px' } } }}
+            >
+                <DialogContent sx={{ p: 3, pt: 2, position: 'relative' }}>
+                    <IconButton
+                        size="small"
+                        onClick={() => this.setState({ dialogOpen: false })}
+                        sx={{ position: 'absolute', top: 8, right: 8 }}
+                    >
+                        <Close fontSize="small" />
+                    </IconButton>
+
+                    <Typography
+                        variant="h6"
+                        sx={{ fontWeight: 600, mb: 2, pr: 4 }}
+                    >
+                        {this.props.settings?.name || name || '...'}
+                    </Typography>
+
+                    <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2, ...dimmedSx }}>
+                        <Box sx={{ fontSize: 64, '& .MuiSvgIcon-root': { fontSize: 'inherit !important' } }}>
+                            {this.renderTileIcon()}
+                        </Box>
+                    </Box>
+
+                    {this.powerId ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+                            <Button
+                                variant={power ? 'contained' : 'outlined'}
+                                color={power ? 'success' : 'inherit'}
+                                startIcon={<PowerSettingsNew />}
+                                disabled={this.isReadOnly || !this.powerTypeKnown}
+                                onClick={this.togglePower}
+                                size="small"
+                                sx={{ textTransform: 'none', borderRadius: '20px' }}
+                            >
+                                {I18n.t('wm_On/Off')}
+                            </Button>
+                        </Box>
+                    ) : null}
+
+                    {this.renderSpeedControl(dimmedSx)}
+
+                    {this.speedLevelId ? (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography
+                                variant="body2"
+                                sx={{ fontWeight: 600, mb: 0.75, color: 'text.secondary' }}
+                            >
+                                <Air sx={{ fontSize: 16, verticalAlign: 'middle', mr: 0.5 }} />
+                                {I18n.t('wm_Fan level')}
+                            </Typography>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, ...dimmedSx }}>
+                                <Slider
+                                    disabled={this.isReadOnly}
+                                    value={speedLevel ?? speedLevelRange.min}
+                                    min={speedLevelRange.min}
+                                    max={speedLevelRange.max}
+                                    step={speedLevelRange.step}
+                                    valueLabelDisplay="auto"
+                                    onChange={(_e, value) => {
+                                        if (!Array.isArray(value)) {
+                                            this.speedLevelDragging = true;
+                                            this.setState({ speedLevel: value });
+                                        }
+                                    }}
+                                    onChangeCommitted={(_e, value) => {
+                                        this.speedLevelDragging = false;
+                                        if (!Array.isArray(value)) {
+                                            this.setSpeedLevel(value);
+                                        }
+                                    }}
+                                    sx={{ flex: 1 }}
+                                />
+                                <Typography
+                                    variant="body2"
+                                    sx={{ color: 'text.secondary', minWidth: 42, textAlign: 'right' }}
+                                >
+                                    {speedLevel == null
+                                        ? '—'
+                                        : `${Math.round(speedLevel)}${speedLevelUnit ? ` ${speedLevelUnit}` : ''}`}
+                                </Typography>
+                            </Box>
+                        </Box>
+                    ) : null}
+
+                    {airflowEntries.length > 0 ? (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography
+                                variant="body2"
+                                sx={{ fontWeight: 600, mb: 0.75, color: 'text.secondary' }}
+                            >
+                                <SwapHoriz sx={{ fontSize: 16, verticalAlign: 'middle', mr: 0.5 }} />
+                                {I18n.t('wm_Airflow direction')}
+                            </Typography>
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 0.75,
+                                    justifyContent: 'center',
+                                    flexWrap: 'wrap',
+                                    ...dimmedSx,
+                                }}
+                            >
+                                {airflowEntries.map(([key, label]) => {
+                                    const value = stateKeyToValue(key);
+                                    const isActive = airflow != null && String(airflow) === key;
+                                    return (
+                                        <Button
+                                            key={key}
+                                            variant={isActive ? 'contained' : 'outlined'}
+                                            color={isActive ? 'primary' : 'inherit'}
+                                            disabled={this.isReadOnly}
+                                            onClick={() => this.setAirflow(value)}
+                                            size="small"
+                                            sx={{ textTransform: 'none', borderRadius: '20px', minWidth: 0, px: 1.5 }}
+                                        >
+                                            {WidgetFanBase.getAirflowLabel(label)}
+                                        </Button>
+                                    );
+                                })}
+                            </Box>
+                        </Box>
+                    ) : null}
+
+                    {this.swingId && (swingIsBoolean || swingEntries.length > 0) ? (
+                        <Box>
+                            <Typography
+                                variant="body2"
+                                sx={{ fontWeight: 600, mb: 0.75, color: 'text.secondary' }}
+                            >
+                                <SwapVert sx={{ fontSize: 16, verticalAlign: 'middle', mr: 0.5 }} />
+                                {I18n.t('wm_Swing')}
+                            </Typography>
+                            {swingIsBoolean ? (
+                                <Box sx={{ display: 'flex', justifyContent: 'center', ...dimmedSx }}>
+                                    <Button
+                                        variant={swing ? 'contained' : 'outlined'}
+                                        color={swing ? 'primary' : 'inherit'}
+                                        disabled={this.isReadOnly}
+                                        onClick={() => this.setSwing(!swing)}
+                                        size="small"
+                                        sx={{ textTransform: 'none', borderRadius: '20px' }}
+                                    >
+                                        {swing ? I18n.t('wm_On') : I18n.t('wm_Off')}
+                                    </Button>
+                                </Box>
+                            ) : (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 0.75,
+                                        justifyContent: 'center',
+                                        flexWrap: 'wrap',
+                                        ...dimmedSx,
+                                    }}
+                                >
+                                    {swingEntries.map(([key, label]) => {
+                                        const value = this.swingListValue(key, swingKeys);
+                                        const isActive = swing != null && String(swing) === key;
+                                        return (
+                                            <Button
+                                                key={key}
+                                                variant={isActive ? 'contained' : 'outlined'}
+                                                color={isActive ? 'primary' : 'inherit'}
+                                                disabled={this.isReadOnly}
+                                                onClick={() => this.setSwing(value)}
+                                                size="small"
+                                                sx={{
+                                                    textTransform: 'none',
+                                                    borderRadius: '20px',
+                                                    minWidth: 0,
+                                                    px: 1.5,
+                                                }}
+                                            >
+                                                {WidgetFanBase.getSwingLabel(label)}
+                                            </Button>
+                                        );
+                                    })}
+                                </Box>
+                            )}
+                        </Box>
+                    ) : null}
+                </DialogContent>
+            </Dialog>
+        );
+    }
+
+    render(): React.JSX.Element {
+        return (
+            <>
+                {super.render()}
+                {this.renderControlDialog()}
+            </>
+        );
+    }
+}
+
+export default WidgetFanBase;

--- a/src-admin/src/WidgetsManager/Widgets/index.ts
+++ b/src-admin/src/WidgetsManager/Widgets/index.ts
@@ -1,5 +1,6 @@
 export { WidgetPlugin } from './WidgetPlugin';
 export { WidgetAirCondition } from './AirCondition';
+export { WidgetAirPurifier } from './AirPurifier';
 export { WidgetBlind } from './Blind';
 export { WidgetBlindButtons } from './BlindButtons';
 export { WidgetButton } from './Button';
@@ -12,6 +13,7 @@ export { WidgetContact } from './Contact';
 export { WidgetDimmer } from './Dimmer';
 export { WidgetDoor } from './Door';
 export { WidgetEnergyFlow, type WidgetEnergyFlowSettings } from './EnergyFlow';
+export { WidgetFan } from './Fan';
 export { WidgetFireAlarm } from './FireAlarm';
 export { WidgetFloodAlarm } from './FloodAlarm';
 export { WidgetFlow } from './Flow';

--- a/src-admin/src/WidgetsManager/i18n/de.json
+++ b/src-admin/src/WidgetsManager/i18n/de.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Ventil",
     "wm_Filter condition": "Filterzustand",
     "wm_Carbon filter condition": "Zustand Kohlefilter",
-    "wm_Window open": "Fenster offen"
+    "wm_Window open": "Fenster offen",
+    "wm_Fan": "Ventilator",
+    "wm_Air purifier": "Luftreiniger"
 }

--- a/src-admin/src/WidgetsManager/i18n/en.json
+++ b/src-admin/src/WidgetsManager/i18n/en.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Valve",
     "wm_Filter condition": "Filter condition",
     "wm_Carbon filter condition": "Carbon filter condition",
-    "wm_Window open": "Window open"
+    "wm_Window open": "Window open",
+    "wm_Fan": "Fan",
+    "wm_Air purifier": "Air purifier"
 }

--- a/src-admin/src/WidgetsManager/i18n/es.json
+++ b/src-admin/src/WidgetsManager/i18n/es.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Válvula",
     "wm_Filter condition": "Estado del filtro",
     "wm_Carbon filter condition": "Estado del filtro de carbón",
-    "wm_Window open": "Ventana abierta"
+    "wm_Window open": "Ventana abierta",
+    "wm_Fan": "Ventilador",
+    "wm_Air purifier": "Purificador de aire"
 }

--- a/src-admin/src/WidgetsManager/i18n/fr.json
+++ b/src-admin/src/WidgetsManager/i18n/fr.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Vanne",
     "wm_Filter condition": "État du filtre",
     "wm_Carbon filter condition": "État du filtre à charbon",
-    "wm_Window open": "Fenêtre ouverte"
+    "wm_Window open": "Fenêtre ouverte",
+    "wm_Fan": "Ventilateur",
+    "wm_Air purifier": "Purificateur d'air"
 }

--- a/src-admin/src/WidgetsManager/i18n/it.json
+++ b/src-admin/src/WidgetsManager/i18n/it.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Valvola",
     "wm_Filter condition": "Stato del filtro",
     "wm_Carbon filter condition": "Stato del filtro a carbone",
-    "wm_Window open": "Finestra aperta"
+    "wm_Window open": "Finestra aperta",
+    "wm_Fan": "Ventilatore",
+    "wm_Air purifier": "Purificatore d'aria"
 }

--- a/src-admin/src/WidgetsManager/i18n/nl.json
+++ b/src-admin/src/WidgetsManager/i18n/nl.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Ventiel",
     "wm_Filter condition": "Filterstatus",
     "wm_Carbon filter condition": "Status koolstoffilter",
-    "wm_Window open": "Raam open"
+    "wm_Window open": "Raam open",
+    "wm_Fan": "Ventilator",
+    "wm_Air purifier": "Luchtreiniger"
 }

--- a/src-admin/src/WidgetsManager/i18n/pl.json
+++ b/src-admin/src/WidgetsManager/i18n/pl.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Zawór",
     "wm_Filter condition": "Stan filtra",
     "wm_Carbon filter condition": "Stan filtra węglowego",
-    "wm_Window open": "Okno otwarte"
+    "wm_Window open": "Okno otwarte",
+    "wm_Fan": "Wentylator",
+    "wm_Air purifier": "Oczyszczacz powietrza"
 }

--- a/src-admin/src/WidgetsManager/i18n/pt.json
+++ b/src-admin/src/WidgetsManager/i18n/pt.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Válvula",
     "wm_Filter condition": "Estado do filtro",
     "wm_Carbon filter condition": "Estado do filtro de carvão",
-    "wm_Window open": "Janela aberta"
+    "wm_Window open": "Janela aberta",
+    "wm_Fan": "Ventilador",
+    "wm_Air purifier": "Purificador de ar"
 }

--- a/src-admin/src/WidgetsManager/i18n/ru.json
+++ b/src-admin/src/WidgetsManager/i18n/ru.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Клапан",
     "wm_Filter condition": "Состояние фильтра",
     "wm_Carbon filter condition": "Состояние угольного фильтра",
-    "wm_Window open": "Окно открыто"
+    "wm_Window open": "Окно открыто",
+    "wm_Fan": "Вентилятор",
+    "wm_Air purifier": "Очиститель воздуха"
 }

--- a/src-admin/src/WidgetsManager/i18n/uk.json
+++ b/src-admin/src/WidgetsManager/i18n/uk.json
@@ -573,5 +573,7 @@
     "wm_Valve": "Клапан",
     "wm_Filter condition": "Стан фільтра",
     "wm_Carbon filter condition": "Стан вугільного фільтра",
-    "wm_Window open": "Вікно відкрито"
+    "wm_Window open": "Вікно відкрито",
+    "wm_Fan": "Вентилятор",
+    "wm_Air purifier": "Очищувач повітря"
 }

--- a/src-admin/src/WidgetsManager/i18n/zh-cn.json
+++ b/src-admin/src/WidgetsManager/i18n/zh-cn.json
@@ -573,5 +573,7 @@
     "wm_Valve": "阀门",
     "wm_Filter condition": "滤网状态",
     "wm_Carbon filter condition": "活性炭滤网状态",
-    "wm_Window open": "窗户已打开"
+    "wm_Window open": "窗户已打开",
+    "wm_Fan": "风扇",
+    "wm_Air purifier": "空气净化器"
 }


### PR DESCRIPTION
Tier C of the 6.0.0 work: `fan` and `airPurifier`. One commit, source only, based on master.

Both types have rendered a **"widget type not supported"** placeholder since the bump. #661 declined to
park them on a read-only value tile the way `contact`/`pressure`/`flow` were parked, and that was
right: these are controls, and a tile that cannot operate the device misrepresents it.

Independent of #665 and #666 — branched from master, and neither type sits in the info-tile stopgap
arm, so this only *adds* arms to `Category.tsx` rather than rewriting the block #665 rewrites.

## One base, two thin subclasses

Both patterns declare an identical control surface, verified against the installed detector:

```
SPEED (required, a labelled list)   POWER   SPEED_LEVEL   SWING   AIRFLOW_DIRECTION   ON_TIME
+ the five electricity readings
```

`Fan.tsx` and `AirPurifier.tsx` are 23 lines each: an icon and a settings title. Everything else is
`FanBase.tsx`.

**An air purifier's filter readings need no widget code.** `FILTER_CONDITION` and
`FILTER_CONDITION_CARBON` are read-only percentages already in `EXTRA_INFO_NAMES` (#664), so they
arrive in the "i" dialog with a unit, a history and a chart; `FILTER_CHANGE` is already an indicator
(#663). `ON_TIME` is likewise implemented once in `WidgetGeneric` for the eleven types that carry it.
The base renders none of them.

The base is **modelled on `WidgetAirCondition`, not extracted from it** — that widget is shipping, #666
touches it, and adopting a shared base there is a separate decision. `AirCondition.tsx` is untouched by
this PR.

## A value the widget cannot type correctly is not written

`POWER` is `boolean|number` in the pattern, so the type belongs to the datapoint: it comes from the
object, or from the first live value when the object cannot be read, and **the control stays disabled
until one of the two has said which it is.** Previously a click in that window wrote a boolean to a
numeric datapoint.

A value list may be keyed by string (`'AUTO'`) or by number, and may arrive as an object, an array or a
`"0:Auto;1:High"` string. Every list goes through the shared `commonStates.ts` parser rather than
`Number()`, which turns `'AUTO'` into `NaN` and drops the write — the same failure #654 fixed for the
air conditioner.

## A datapoint that declares no value list still gets a control

Nothing obliges a datapoint to carry `common.states`, and a numeric `SWING` or `AIRFLOW_DIRECTION`
without one had a valid writable id and **no user interface at all**. The pattern's own
`defaultStates` are what those values mean and they do reach the widget, so they stand in:

```
bare numeric datapoints, no common.states anywhere  [fan]
    SPEED: AUTO/HIGH/LOW/MEDIUM/QUIET/TURBO
    SWING: AUTO/HORIZONTAL/STATIONARY/VERTICAL
    AIRFLOW_DIRECTION: FORWARD/REVERSE
device declares its own lists  [fan]
    SPEED: Slow/Fast    SWING: Off/Wide    AIRFLOW_DIRECTION: In/Out
```

Three rules make that safe:
- A list the device declares itself always wins.
- A declared numeric range beats the pattern's labels — it is this device's own statement about what
  the datapoint accepts, and it is trusted only when *both* bounds are explicit, so an rpm-scale speed
  is never pinned to 0–100.
- The fallback is applied **only once the datapoint's object has been read**, never at construction: a
  boolean `SWING` can take none of the four values the numeric variant declares, and a click in that
  window would have written `2` to a boolean datapoint.

`WidgetAirCondition` has the same missing-list gap. Not fixed here — same reason as above.

## A boolean SWING with its own labels keeps both options reachable

A boolean datapoint shipping `{"Off":"Off","On":"On"}` previously mapped **both** buttons to `false`,
making "On" unreachable. Only `0`/`1` and `false`/`true` say which of the two a value is; exactly two
unrecognised keys are taken in declaration order; anything else keeps its own key and lets the
datapoint decide.

## Permissions and echoes

Nothing is written outside `setValue()`, which is the only place the read-only view permission is
enforced, and every control — power, the speed list/slider/field, speed level, swing, airflow — carries
`disabled={this.isReadOnly}`. No discrete control updates optimistically; the subscription reports what
the device accepted, so a rejected write cannot leave a value on screen the device never took. The two
sliders are the exception while a drag is in progress, each with its own guard so a device echo cannot
fight the pointer.

## Registration

Two arms in `Category.tsx`, placed with the climate family, and two exports. `TYPE_TO_GROUP` already
mapped both to `climate` and `TYPE_OPTIONS` already carried both from #661 — no new unverifiable claims
about alexa/alisa/google/material support.

Two new i18n keys, `wm_Fan` and `wm_Air purifier`, in all 11 languages (575 → 577, key sets identical).
Everything else reuses the speed/swing/airflow labels the air-conditioner work already added.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, full `npm run build`,
`test:unit` (77) and `test:package` (47).

Every pattern claim was checked by running the real `ChannelDetector` over synthetic devices, including
the fallback behaviour quoted above, a device declaring both `SWING` variants, and a boolean-only swing.

No unit tests added: this is React class components throughout, and the pure helper it leans on
(`commonStates.ts`) is already covered by `test/commonStates.test.js`.

## Notes for review

- **`FanBase.tsx` is 856 lines**, and the largest judgement call in it is the `SPEED` fallback chain
  (labelled list → declared range → plain number field). `SPEED` is the one state both patterns
  require, so leaving it uncontrollable when a datapoint declares nothing seemed worse than the extra
  code — but it is the part most reasonable to trim.
- A powered-off tile still shows its last known speed label. That matches `WidgetAirCondition`'s
  convention: it is real reported data, not a fabricated value.

## Follow-ups

- **Tier B** — `electricity`, deliberately held until #665 lands: it has to be removed from exactly the
  stopgap arm that PR rewrites.
- **PR 6 tier D** — `pump`, then `airQuality` on its own.
- `WidgetAirCondition` could adopt this base, and `Illuminance`/`Humidity`/`Temperature` could adopt
  #665's `SingleValueSensorBase`. Both are retro-fits of shipping widgets, so both are their own change.
- **[adapter-react-v5#123](https://github.com/ioBroker/adapter-react-v5/issues/123)** — still no icon or
  `type-*` name in gui-components for any of the nine new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
