### PR TITLE
feat(widgets): a tile for the electricity device type

### DIFF
--- a/src-admin/src/Components/helpers/roleIcons.ts
+++ b/src-admin/src/Components/helpers/roleIcons.ts
@@ -32,8 +32,10 @@ export const ROLE_ICON_MAP: [RegExp, SvgIconComponent][] = [
     [/pressure|baro/i, Speed],
     [/voltage/i, Bolt],
     [/current(?!.*weather)/i, ElectricalServices],
-    [/power|watt/i, ElectricMeter],
+    // Before the power pattern: `value.power.consumption` contains "power", so the general pattern
+    // would claim it and a meter would show the same icon for its power and its energy reading.
     [/energy|consumption|\bk?wh\b/i, EnergySavingsLeaf],
+    [/power|watt/i, ElectricMeter],
     // Bare unit abbreviations, checked after the spelled-out roles so "value.energy" keeps its own
     // icon. The word boundaries keep "kWh" and "Wh" out — those are energy, not power.
     [/\bw\b|\bkw\b|\bmw\b/i, ElectricMeter],

--- a/src-admin/src/WidgetsManager/Category.tsx
+++ b/src-admin/src/WidgetsManager/Category.tsx
@@ -75,6 +75,7 @@ import {
     WidgetCoAlarm,
     WidgetContact,
     WidgetDoor,
+    WidgetElectricity,
     WidgetFloodAlarm,
     WidgetFireAlarm,
     WidgetFlow,
@@ -2227,12 +2228,11 @@ export default class Category extends Component<CategoryProps, CategoryState> {
             Widget = WidgetPressure;
         } else if (type === Types.flow) {
             Widget = WidgetFlow;
-        } else if (
-            // Types split out of `info` by type-detector 6.0.0. These devices were rendered as info
-            // tiles before, so they keep that tile until each gets a purpose-built one.
-            type === Types.airQuality ||
-            type === Types.electricity
-        ) {
+        } else if (type === Types.electricity) {
+            Widget = WidgetElectricity;
+        } else if (type === Types.airQuality) {
+            // Split out of `info` by type-detector 6.0.0 and rendered as an info tile before, so it
+            // keeps that tile until it gets the purpose-built one its 29 states deserve.
             Widget = WidgetInfoWidget;
         } else if (type === Types.lock) {
             Widget = WidgetLock;

--- a/src-admin/src/WidgetsManager/Widgets/Electricity.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Electricity.tsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { ElectricMeter } from '@mui/icons-material';
+
+import WidgetGeneric, {
+    formatFloat,
+    toNumberOrNull,
+    type WidgetGenericProps,
+    type WidgetGenericState,
+} from './Generic';
+import { hideBaseFields } from '../configUtils';
+import { getIconForRole } from '../../Components/helpers/roleIcons';
+import type { ConfigItemPanel } from '@iobroker/json-config';
+
+/**
+ * All five readings sit in one `requiredOneOf` detector group — a device may declare any single one
+ * of them and nothing else (e.g. a device metering only consumption, or only frequency). This order
+ * is both the primary-reading preference and, applied a second time over what's left, the
+ * secondary-reading preference, so a device with just one reading still shows something.
+ */
+const READING_ORDER = ['ELECTRIC_POWER', 'CONSUMPTION', 'CURRENT', 'VOLTAGE', 'FREQUENCY'] as const;
+type ReadingName = (typeof READING_ORDER)[number];
+
+const READING_ROLE: Record<ReadingName, string> = {
+    ELECTRIC_POWER: 'value.power',
+    CONSUMPTION: 'value.power.consumption',
+    CURRENT: 'value.current',
+    VOLTAGE: 'value.voltage',
+    FREQUENCY: 'value.frequency',
+};
+
+interface ReadingMeta {
+    id: string;
+    /** `common.unit` as declared on the state itself, `''` when the device declares none */
+    unit: string;
+}
+
+interface WidgetElectricityState extends WidgetGenericState {
+    values: Partial<Record<ReadingName, number | null>>;
+}
+
+export class WidgetElectricity extends WidgetGeneric<WidgetElectricityState> {
+    static override getConfigSchema(): { name: string; schema: ConfigItemPanel } {
+        return {
+            name: 'wm_Electricity',
+            schema: { type: 'panel', items: { ...hideBaseFields('colorActive', 'color') } },
+        };
+    }
+
+    private readonly readingMeta: Partial<Record<ReadingName, ReadingMeta>> = {};
+    private readonly primaryName: ReadingName | null;
+    private readonly secondaryName: ReadingName | null;
+    /** Tile-face state IDs only — the "i" dialog's own subscription to all five is Generic's job. */
+    private readonly idToName: Record<string, ReadingName> = {};
+
+    constructor(props: WidgetGenericProps) {
+        super(props);
+        const states = props.widget.control.states;
+        for (const name of READING_ORDER) {
+            const match = states.find(s => s.name === name && s.id);
+            if (match) {
+                this.readingMeta[name] = { id: match.id, unit: match.unit || '' };
+            }
+        }
+
+        this.primaryName = READING_ORDER.find(name => this.readingMeta[name]) ?? null;
+        this.secondaryName = READING_ORDER.find(name => name !== this.primaryName && this.readingMeta[name]) ?? null;
+
+        const values: Partial<Record<ReadingName, number | null>> = {};
+        for (const name of [this.primaryName, this.secondaryName]) {
+            if (name) {
+                values[name] = null;
+                this.idToName[this.readingMeta[name]!.id] = name;
+            }
+        }
+
+        this.state = {
+            ...this.state,
+            values,
+        };
+    }
+
+    componentDidMount(): void {
+        super.componentDidMount();
+        for (const id of Object.keys(this.idToName)) {
+            this.props.stateContext.getState(id, this.onReadingChange);
+        }
+    }
+
+    componentWillUnmount(): void {
+        super.componentWillUnmount();
+        for (const id of Object.keys(this.idToName)) {
+            this.props.stateContext.removeState(id, this.onReadingChange);
+        }
+    }
+
+    private onReadingChange = (id: string, state: ioBroker.State): void => {
+        const name = this.idToName[id];
+        if (!name) {
+            return;
+        }
+        const value = toNumberOrNull(state.val);
+        if (this.state.values[name] !== value) {
+            this.setState(prev => ({ values: { ...prev.values, [name]: value } }));
+        }
+    };
+
+    protected getHistoryIds(): { id: string; color: string }[] {
+        const ids: { id: string; color: string }[] = [];
+        if (this.primaryName) {
+            ids.push({ id: this.readingMeta[this.primaryName]!.id, color: '#f9a825' });
+        }
+        if (this.secondaryName) {
+            ids.push({ id: this.readingMeta[this.secondaryName]!.id, color: '#4caf50' });
+        }
+        return ids;
+    }
+
+    protected getChartUnit(): string | undefined {
+        return (this.primaryName && this.readingMeta[this.primaryName]?.unit) || undefined;
+    }
+
+    protected isTileActive(): boolean {
+        return !!this.primaryName && this.state.values[this.primaryName] != null;
+    }
+
+    /** Format one reading's current value, scaling power/consumption but never inventing a unit. */
+    private formatReading(name: ReadingName): string {
+        const value = this.state.values[name];
+        if (value == null) {
+            return '—';
+        }
+        const unit = this.readingMeta[name]?.unit || '';
+        // Shown at the scale the device declared, never converted: the same reading appears again as
+        // an extra-info row in the "i" dialog, which shows it raw, and one tile stating a value two
+        // ways reads as two measurements.
+        const abs = Math.abs(value);
+        const decimals = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+        const str = formatFloat(value, decimals, this.props.stateContext.isFloatComma);
+        return unit ? `${str} ${unit}` : str;
+    }
+
+    private renderReadingIcon(name: ReadingName, fontSize: number): React.JSX.Element | null {
+        const unit = this.readingMeta[name]?.unit || '';
+        const IconComp = getIconForRole(READING_ROLE[name], unit);
+        if (!IconComp) {
+            return null;
+        }
+        return <IconComp sx={{ fontSize, color: 'text.secondary', flexShrink: 0 }} />;
+    }
+
+    protected renderTileIcon(): React.JSX.Element {
+        const baseIcon = super.renderTileIcon();
+        if (baseIcon) {
+            return baseIcon;
+        }
+
+        if (!this.primaryName) {
+            return <ElectricMeter sx={{ color: 'text.disabled' }} />;
+        }
+        const unit = this.readingMeta[this.primaryName]?.unit || '';
+        const IconComp = getIconForRole(READING_ROLE[this.primaryName], unit) || ElectricMeter;
+        const isActive = this.isTileActive();
+        return (
+            <IconComp
+                sx={{
+                    color: isActive ? '#f9a825' : 'text.disabled',
+                    transition: 'color 0.25s ease',
+                }}
+            />
+        );
+    }
+
+    protected renderTileStatus(): React.JSX.Element | null {
+        // Every layout but the 1x1 shows the reading through renderTileAction — rendering it here
+        // as well would print the same value twice on one tile.
+        const size = this.props.settings?.size || '1x1';
+        if (size !== '1x1' || !this.primaryName) {
+            return null;
+        }
+
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Typography
+                    variant="caption"
+                    sx={{
+                        fontWeight: 600,
+                        fontSize: '1.1rem',
+                        lineHeight: 1.2,
+                        color: 'text.primary',
+                    }}
+                >
+                    {this.formatReading(this.primaryName)}
+                </Typography>
+                {this.secondaryName ? (
+                    <Typography
+                        variant="caption"
+                        sx={{
+                            fontWeight: 500,
+                            color: 'text.secondary',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '2px',
+                        }}
+                    >
+                        {this.renderReadingIcon(this.secondaryName, 12)}
+                        {this.formatReading(this.secondaryName)}
+                    </Typography>
+                ) : null}
+            </Box>
+        );
+    }
+
+    protected renderTileAction(): React.JSX.Element | null {
+        if (!this.primaryName) {
+            return null;
+        }
+
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+                <Typography
+                    variant="h5"
+                    sx={{ fontWeight: 700, whiteSpace: 'nowrap' }}
+                >
+                    {this.formatReading(this.primaryName)}
+                </Typography>
+                {this.secondaryName ? (
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            color: 'text.secondary',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '3px',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {this.renderReadingIcon(this.secondaryName, 14)}
+                        {this.formatReading(this.secondaryName)}
+                    </Typography>
+                ) : null}
+            </Box>
+        );
+    }
+}
+
+export default WidgetElectricity;

--- a/src-admin/src/WidgetsManager/Widgets/Electricity.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Electricity.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { ElectricMeter } from '@mui/icons-material';
+import { I18n } from '@iobroker/gui-components';
 
 import WidgetGeneric, {
     formatFloat,
@@ -20,6 +21,14 @@ import type { ConfigItemPanel } from '@iobroker/json-config';
  */
 const READING_ORDER = ['ELECTRIC_POWER', 'CONSUMPTION', 'CURRENT', 'VOLTAGE', 'FREQUENCY'] as const;
 type ReadingName = (typeof READING_ORDER)[number];
+
+const READING_LABEL: Record<ReadingName, string> = {
+    ELECTRIC_POWER: 'wm_Power',
+    CONSUMPTION: 'wm_Consumption',
+    CURRENT: 'wm_Current',
+    VOLTAGE: 'wm_Voltage',
+    FREQUENCY: 'wm_Frequency',
+};
 
 const READING_ROLE: Record<ReadingName, string> = {
     ELECTRIC_POWER: 'value.power',
@@ -105,26 +114,44 @@ export class WidgetElectricity extends WidgetGeneric<WidgetElectricityState> {
         }
     };
 
-    protected getHistoryIds(): { id: string; color: string }[] {
-        const ids: { id: string; color: string }[] = [];
+    protected getHistoryIds(): { id: string; color: string; name?: string }[] {
+        const ids: { id: string; color: string; name?: string }[] = [];
         if (this.primaryName) {
-            ids.push({ id: this.readingMeta[this.primaryName]!.id, color: '#f9a825' });
+            ids.push({
+                id: this.readingMeta[this.primaryName]!.id,
+                color: '#f9a825',
+                name: I18n.t(READING_LABEL[this.primaryName]),
+            });
         }
         if (this.secondaryName) {
-            ids.push({ id: this.readingMeta[this.secondaryName]!.id, color: '#4caf50' });
+            ids.push({
+                id: this.readingMeta[this.secondaryName]!.id,
+                color: '#4caf50',
+                name: I18n.t(READING_LABEL[this.secondaryName]),
+            });
         }
         return ids;
     }
 
+    /**
+     * The unit shown for every plotted series, so it may only be given when it is true of all of them.
+     *
+     * Two readings whose units differ are plotted on their own axes and carry their own labels; two
+     * where only one declares a unit are not, and naming that one here would label the other's values
+     * with a unit its device never reported.
+     */
     protected getChartUnit(): string | undefined {
-        return (this.primaryName && this.readingMeta[this.primaryName]?.unit) || undefined;
+        const units = [this.primaryName, this.secondaryName]
+            .filter((name): name is ReadingName => !!name)
+            .map(name => this.readingMeta[name]?.unit || '');
+        return units.length && units.every(unit => unit === units[0]) ? units[0] || undefined : undefined;
     }
 
     protected isTileActive(): boolean {
         return !!this.primaryName && this.state.values[this.primaryName] != null;
     }
 
-    /** Format one reading's current value, scaling power/consumption but never inventing a unit. */
+    /** Format one reading's current value at the scale the device declared, never inventing a unit. */
     private formatReading(name: ReadingName): string {
         const value = this.state.values[name];
         if (value == null) {

--- a/src-admin/src/WidgetsManager/Widgets/index.ts
+++ b/src-admin/src/WidgetsManager/Widgets/index.ts
@@ -11,6 +11,7 @@ export { WidgetColorLight } from './ColorLight';
 export { WidgetContact } from './Contact';
 export { WidgetDimmer } from './Dimmer';
 export { WidgetDoor } from './Door';
+export { WidgetElectricity } from './Electricity';
 export { WidgetEnergyFlow, type WidgetEnergyFlowSettings } from './EnergyFlow';
 export { WidgetFireAlarm } from './FireAlarm';
 export { WidgetFloodAlarm } from './FloodAlarm';

--- a/src-admin/src/WidgetsManager/i18n/de.json
+++ b/src-admin/src/WidgetsManager/i18n/de.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Ventil",
     "wm_Filter condition": "Filterzustand",
     "wm_Carbon filter condition": "Zustand Kohlefilter",
-    "wm_Window open": "Fenster offen"
+    "wm_Window open": "Fenster offen",
+    "wm_Electricity": "Stromzähler"
 }

--- a/src-admin/src/WidgetsManager/i18n/en.json
+++ b/src-admin/src/WidgetsManager/i18n/en.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Valve",
     "wm_Filter condition": "Filter condition",
     "wm_Carbon filter condition": "Carbon filter condition",
-    "wm_Window open": "Window open"
+    "wm_Window open": "Window open",
+    "wm_Electricity": "Electricity"
 }

--- a/src-admin/src/WidgetsManager/i18n/es.json
+++ b/src-admin/src/WidgetsManager/i18n/es.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Válvula",
     "wm_Filter condition": "Estado del filtro",
     "wm_Carbon filter condition": "Estado del filtro de carbón",
-    "wm_Window open": "Ventana abierta"
+    "wm_Window open": "Ventana abierta",
+    "wm_Electricity": "Electricidad"
 }

--- a/src-admin/src/WidgetsManager/i18n/fr.json
+++ b/src-admin/src/WidgetsManager/i18n/fr.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Vanne",
     "wm_Filter condition": "État du filtre",
     "wm_Carbon filter condition": "État du filtre à charbon",
-    "wm_Window open": "Fenêtre ouverte"
+    "wm_Window open": "Fenêtre ouverte",
+    "wm_Electricity": "Électricité"
 }

--- a/src-admin/src/WidgetsManager/i18n/it.json
+++ b/src-admin/src/WidgetsManager/i18n/it.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Valvola",
     "wm_Filter condition": "Stato del filtro",
     "wm_Carbon filter condition": "Stato del filtro a carbone",
-    "wm_Window open": "Finestra aperta"
+    "wm_Window open": "Finestra aperta",
+    "wm_Electricity": "Elettricità"
 }

--- a/src-admin/src/WidgetsManager/i18n/nl.json
+++ b/src-admin/src/WidgetsManager/i18n/nl.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Ventiel",
     "wm_Filter condition": "Filterstatus",
     "wm_Carbon filter condition": "Status koolstoffilter",
-    "wm_Window open": "Raam open"
+    "wm_Window open": "Raam open",
+    "wm_Electricity": "Elektriciteit"
 }

--- a/src-admin/src/WidgetsManager/i18n/pl.json
+++ b/src-admin/src/WidgetsManager/i18n/pl.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Zawór",
     "wm_Filter condition": "Stan filtra",
     "wm_Carbon filter condition": "Stan filtra węglowego",
-    "wm_Window open": "Okno otwarte"
+    "wm_Window open": "Okno otwarte",
+    "wm_Electricity": "Elektryczność"
 }

--- a/src-admin/src/WidgetsManager/i18n/pt.json
+++ b/src-admin/src/WidgetsManager/i18n/pt.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Válvula",
     "wm_Filter condition": "Estado do filtro",
     "wm_Carbon filter condition": "Estado do filtro de carvão",
-    "wm_Window open": "Janela aberta"
+    "wm_Window open": "Janela aberta",
+    "wm_Electricity": "Eletricidade"
 }

--- a/src-admin/src/WidgetsManager/i18n/ru.json
+++ b/src-admin/src/WidgetsManager/i18n/ru.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Клапан",
     "wm_Filter condition": "Состояние фильтра",
     "wm_Carbon filter condition": "Состояние угольного фильтра",
-    "wm_Window open": "Окно открыто"
+    "wm_Window open": "Окно открыто",
+    "wm_Electricity": "Электричество"
 }

--- a/src-admin/src/WidgetsManager/i18n/uk.json
+++ b/src-admin/src/WidgetsManager/i18n/uk.json
@@ -573,5 +573,6 @@
     "wm_Valve": "Клапан",
     "wm_Filter condition": "Стан фільтра",
     "wm_Carbon filter condition": "Стан вугільного фільтра",
-    "wm_Window open": "Вікно відкрито"
+    "wm_Window open": "Вікно відкрито",
+    "wm_Electricity": "Електрика"
 }

--- a/src-admin/src/WidgetsManager/i18n/zh-cn.json
+++ b/src-admin/src/WidgetsManager/i18n/zh-cn.json
@@ -573,5 +573,6 @@
     "wm_Valve": "阀门",
     "wm_Filter condition": "滤网状态",
     "wm_Carbon filter condition": "活性炭滤网状态",
-    "wm_Window open": "窗户已打开"
+    "wm_Window open": "窗户已打开",
+    "wm_Electricity": "电量"
 }


### PR DESCRIPTION
Tier B of the 6.0.0 work: `electricity`. One commit, source only, based on master.

This type has been routed to the generic `WidgetInfo` tile since the bump. That was the right stopgap —
#663 made sure it at least shows *a* reading rather than a blank tile — but an info tile shows one value
and labels it with whatever the datapoint is called, which is not a metering device.

## Any one reading detects the type

All five readings sit in a single `requiredOneOf` group, verified against the installed detector:

    ELECTRIC_POWER  CURRENT  VOLTAGE  CONSUMPTION  FREQUENCY

so a device metering **only** consumption, or **only** frequency, is completely valid. A tile built
around power alone therefore comes up blank for it — the exact failure #663 had to fix for the info
tile. One preference order governs both slots on the face: the primary reading, then the secondary from
what remains. Checked by driving the real `ChannelDetector` over each shape:

```
power + consumption + current  face: ELECTRIC_POWER + CONSUMPTION
consumption only               face: CONSUMPTION
frequency only                 face: FREQUENCY
voltage only                   face: VOLTAGE
current only                   face: CURRENT
power declared in kW           face: ELECTRIC_POWER
```

## Readings are shown at the scale the device declared

The pattern's `defaultUnit` is a suggestion; a power datapoint may declare `kW`, a consumption one
`kWh`, a current one `A` rather than `mA`. The declared unit arrives on the state itself, so it is read
from there and printed as-is.

**No conversion, deliberately.** An earlier revision auto-scaled power and energy (`0.4 kW` shown as
`400 W`, the way `Category.tsx` does for its aggregated header totals). The same readings appear again
as extra-info rows in the "i" dialog, which shows them raw — so one tile stated a single reading two
ways, which reads as two measurements. A `kW` device now reads `kW` in both places.

That decision removed a helper module and its 19 unit tests from this PR. They were sound — each of
four mutations (unnormalised `kW`, threshold decided on the un-rounded value, empty string treated as a
value, kilo display forgetting to divide) turned a test red — so if the auto-scaling is wanted later,
the place to put it is `WidgetGeneric`'s extra-info formatting, where the tile and the dialog would
agree. `Category.tsx`'s two private near-duplicates (`normalizeWatts`, `formatPower`) remain the only
copy of that logic; extracting them is worth doing separately.

## Nothing is rendered or subscribed twice

`WidgetGeneric` already subscribes to all five readings and renders them as "i"-dialog rows via
`EXTRA_INFO_NAMES`, complete with unit, history and chart. The widget subscribes only to the one or two
ids it puts on the tile face, and renders no dialog of its own. `renderTileStatus` is guarded with
`size !== '1x1'` — not the `size === '2x0.5'` form that made eight widgets print their value twice, and
which #665 and #666 have just finished fixing.

Read-only throughout: no `setValue()`, no controls. A reading that has not arrived shows `—`, never `0`
— for a meter, "no data" and "measuring zero" are different claims.

## Registration

`electricity` leaves the info-tile stopgap arm, which now holds only `airQuality`, so that multi-type
condition collapses to a single arm carrying the reason the last type is still parked there. One new
i18n key, `wm_Electricity`, in all 11 languages, key sets identical.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, full `npm run build`,
`test:unit` (77) and `test:package` (47). `package.json` is byte-identical to master.

No unit tests added: what remains is a React class component, and the helper that was testable is the
one the scale decision removed.

## Merging alongside #667

Both this and #667 append i18n keys to the end of the same 11 files. A trial merge confirms that is the
**only** conflict — `Category.tsx` and `Widgets/index.ts` merge cleanly, since the two sets of edits
land ~24 lines apart — and the resolution is to keep both sides' keys:

```
<<<<<<< HEAD
    "wm_Fan": "Fan",
    "wm_Air purifier": "Air purifier"
=======
    "wm_Electricity": "Electricity"
>>>>>>> feat/v6-tier-b-electricity
```

Whichever merges second, I will rebase the other and re-run the gates.

## Follow-ups

- **PR 6 tier D** — `pump`, then `airQuality` on its own: 29 non-indicator states, AQI plus eleven
  concentrations each with a parallel `*_LEVEL` enum. The enums are what turn eleven raw numbers into
  something readable, and that is information design, not plumbing.
- Extracting `Category.tsx`'s power helpers, and deciding whether the "i" dialog should auto-scale
  `W`/`Wh` for every widget that carries them.
- **[adapter-react-v5#123](https://github.com/ioBroker/adapter-react-v5/issues/123)** — still no icon or
  `type-*` name in gui-components for any of the nine new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
