### PR TITLE
feat(widgets): a control tile for the pump device type

### DIFF
--- a/src-admin/src/WidgetsManager/Category.tsx
+++ b/src-admin/src/WidgetsManager/Category.tsx
@@ -103,6 +103,7 @@ import {
     WidgetUniversal,
     WidgetVacuumCleaner,
     WidgetPresence,
+    WidgetPump,
     WidgetEnergyFlow,
     WidgetGate,
     WidgetPlugin,
@@ -2256,6 +2257,8 @@ export default class Category extends Component<CategoryProps, CategoryState> {
             Widget = WidgetFan;
         } else if (type === Types.airPurifier) {
             Widget = WidgetAirPurifier;
+        } else if (type === Types.pump) {
+            Widget = WidgetPump;
         } else if (type === Types.warning) {
             Widget = WidgetWarning;
         } else if (type === Types.volume || type === Types.volumeGroup) {

--- a/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
@@ -5,26 +5,7 @@ import { I18n } from '@iobroker/gui-components';
 
 import WidgetGeneric, { toNumberOrNull, type WidgetGenericProps, type WidgetGenericState } from './Generic';
 import { parseCommonStates, stateKeyToValue } from './commonStates';
-import { clampToRange, type SetpointRange as NumericRange } from './climate';
-
-/**
- * A device-declared numeric range, trusted only once both bounds are explicit.
- *
- * A datapoint that declares neither bound has said nothing about its scale, and inventing one caps
- * every write on a device whose native range is wider — an rpm speed pinned to 0–100.
- */
-function explicitRangeFromCommon(common: ioBroker.StateCommon | undefined): NumericRange | null {
-    if (!common || common.min == null || common.max == null) {
-        return null;
-    }
-    const min = Number(common.min);
-    const max = Number(common.max);
-    const step = common.step != null ? Number(common.step) : 1;
-    if (isNaN(min) || isNaN(max) || max <= min) {
-        return null;
-    }
-    return { min, max, step: step > 0 ? step : 1 };
-}
+import { clampToRange, explicitRangeFromCommon, type SetpointRange as NumericRange } from './climate';
 
 /**
  * Control surface shared by `fan` and `airPurifier`: both declare the identical SPEED / POWER /

--- a/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/FanBase.tsx
@@ -339,6 +339,18 @@ export abstract class WidgetFanBase extends WidgetGeneric<WidgetFanBaseState> {
     // an active drag — they must track the pointer — which is why each carries its own dragging guard.
 
     /**
+     * Closing the dialog also ends any drag it held.
+     *
+     * A slider drag that ends by pointer-cancel rather than by a commit event never clears its guard,
+     * and a set guard makes the widget ignore the device's own updates from then on.
+     */
+    private closeDialog = (): void => {
+        this.speedDragging = false;
+        this.speedLevelDragging = false;
+        this.setState({ dialogOpen: false });
+    };
+
+    /**
      * POWER is `boolean|number` in the pattern, so the write has to match the datapoint. Refuses while
      * the type is unknown rather than writing a value the device would reject.
      */
@@ -480,6 +492,16 @@ export abstract class WidgetFanBase extends WidgetGeneric<WidgetFanBaseState> {
     // eslint-disable-next-line class-methods-use-this
     protected hasTileAction(): boolean {
         return true;
+    }
+
+    /**
+     * Openable even for a read-only widget, unlike the base rule.
+     *
+     * The dialog is where a device's own readings are shown, and those stay readable for someone who
+     * may not operate it. Every control inside is disabled independently.
+     */
+    protected tileClickable(): boolean {
+        return this.hasTileAction();
     }
 
     protected onTileClick(): void {
@@ -701,7 +723,7 @@ export abstract class WidgetFanBase extends WidgetGeneric<WidgetFanBaseState> {
         return (
             <Dialog
                 open
-                onClose={() => this.setState({ dialogOpen: false })}
+                onClose={this.closeDialog}
                 maxWidth="xs"
                 fullWidth
                 slotProps={{ paper: { sx: { borderRadius: '24px' } } }}
@@ -709,7 +731,7 @@ export abstract class WidgetFanBase extends WidgetGeneric<WidgetFanBaseState> {
                 <DialogContent sx={{ p: 3, pt: 2, position: 'relative' }}>
                     <IconButton
                         size="small"
-                        onClick={() => this.setState({ dialogOpen: false })}
+                        onClick={this.closeDialog}
                         sx={{ position: 'absolute', top: 8, right: 8 }}
                     >
                         <Close fontSize="small" />

--- a/src-admin/src/WidgetsManager/Widgets/Pump.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Pump.tsx
@@ -1,0 +1,553 @@
+import React from 'react';
+import { Box, Button, Dialog, DialogContent, IconButton, Slider, Typography } from '@mui/material';
+import {
+    Close,
+    Compress,
+    Plumbing,
+    PowerSettingsNew,
+    Speed as SpeedIcon,
+    Thermostat,
+    Waves,
+} from '@mui/icons-material';
+import { I18n } from '@iobroker/gui-components';
+import type { ConfigItemPanel } from '@iobroker/json-config';
+
+import WidgetGeneric, {
+    formatFloat,
+    toNumberOrNull,
+    type WidgetGenericProps,
+    type WidgetGenericState,
+} from './Generic';
+import { clampToRange, explicitRangeFromCommon, type SetpointRange as NumericRange } from './climate';
+
+const ACCENT_COLOR = '#0288d1';
+
+interface WidgetPumpState extends WidgetGenericState {
+    power: boolean | number | null;
+    level: number | null;
+    levelRange: NumericRange;
+    levelUnit: string;
+    temperature: number | null;
+    temperatureUnit: string;
+    pressure: number | null;
+    pressureUnit: string;
+    flow: number | null;
+    flowUnit: string;
+    dialogOpen: boolean;
+}
+
+export class WidgetPump extends WidgetGeneric<WidgetPumpState> {
+    private readonly powerId: string | null;
+    private readonly levelId: string | null;
+    private readonly temperatureId: string | null;
+    private readonly pressureId: string | null;
+    private readonly flowId: string | null;
+
+    /** `common.type` of the power datapoint — POWER is `boolean|number`, and the write must match it */
+    private powerIsNumber = false;
+    /**
+     * Whether that type is known yet.
+     *
+     * Until it is, the widget cannot tell a `boolean` datapoint from a `number` one, and writing the
+     * wrong one is a write the device may reject. The control stays disabled rather than guessing.
+     */
+    private powerTypeKnown = false;
+    /** Held while a slider drag is in progress, so the device's own echo cannot fight the pointer */
+    private levelDragging = false;
+
+    static override getConfigSchema(): { name: string; schema: ConfigItemPanel } {
+        return {
+            name: 'wm_Pump',
+            schema: {
+                type: 'panel',
+                items: {},
+            },
+        };
+    }
+
+    constructor(props: WidgetGenericProps) {
+        super(props);
+        const states = props.widget.control.states;
+        this.powerId = states.find(s => s.name === 'POWER' && s.id)?.id ?? null;
+        const levelState = states.find(s => s.name === 'LEVEL' && s.id);
+        this.levelId = levelState?.id ?? null;
+        const temperatureState = states.find(s => s.name === 'TEMPERATURE' && s.id);
+        this.temperatureId = temperatureState?.id ?? null;
+        const pressureState = states.find(s => s.name === 'PRESSURE' && s.id);
+        this.pressureId = pressureState?.id ?? null;
+        const flowState = states.find(s => s.name === 'FLOW' && s.id);
+        this.flowId = flowState?.id ?? null;
+
+        this.state = {
+            ...this.state,
+            power: null,
+            level: null,
+            levelRange: { min: 0, max: 100, step: 1 },
+            // The backend fills `unit` on the detected state itself, so it is shown before the
+            // datapoint's object has even been fetched; blank until the device actually reports one.
+            levelUnit: levelState?.unit || '',
+            temperature: null,
+            temperatureUnit: temperatureState?.unit || '',
+            pressure: null,
+            pressureUnit: pressureState?.unit || '',
+            flow: null,
+            flowUnit: flowState?.unit || '',
+            dialogOpen: false,
+        };
+    }
+
+    componentDidMount(): void {
+        super.componentDidMount();
+        if (this.powerId) {
+            this.props.stateContext.getState(this.powerId, this.onPowerChange);
+            void this.loadPowerType();
+        }
+        if (this.levelId) {
+            this.props.stateContext.getState(this.levelId, this.onLevelChange);
+            void this.loadLevelRange();
+        }
+        if (this.temperatureId) {
+            this.props.stateContext.getState(this.temperatureId, this.onTemperatureChange);
+        }
+        if (this.pressureId) {
+            this.props.stateContext.getState(this.pressureId, this.onPressureChange);
+        }
+        if (this.flowId) {
+            this.props.stateContext.getState(this.flowId, this.onFlowChange);
+        }
+    }
+
+    componentWillUnmount(): void {
+        super.componentWillUnmount();
+        if (this.powerId) {
+            this.props.stateContext.removeState(this.powerId, this.onPowerChange);
+        }
+        if (this.levelId) {
+            this.props.stateContext.removeState(this.levelId, this.onLevelChange);
+        }
+        if (this.temperatureId) {
+            this.props.stateContext.removeState(this.temperatureId, this.onTemperatureChange);
+        }
+        if (this.pressureId) {
+            this.props.stateContext.removeState(this.pressureId, this.onPressureChange);
+        }
+        if (this.flowId) {
+            this.props.stateContext.removeState(this.flowId, this.onFlowChange);
+        }
+    }
+
+    private async loadPowerType(): Promise<void> {
+        if (!this.powerId) {
+            return;
+        }
+        try {
+            const obj = await this.props.stateContext.getObject<ioBroker.StateObject>(this.powerId);
+            if (obj?.common?.type === 'number' || obj?.common?.type === 'boolean') {
+                this.powerIsNumber = obj.common.type === 'number';
+                this.powerTypeKnown = true;
+                this.forceUpdate();
+            }
+        } catch {
+            // Unreadable object: `onPowerChange` still infers the type from the first live value
+        }
+    }
+
+    private async loadLevelRange(): Promise<void> {
+        if (!this.levelId) {
+            return;
+        }
+        try {
+            const obj = await this.props.stateContext.getObject<ioBroker.StateObject>(this.levelId);
+            const range = explicitRangeFromCommon(obj?.common);
+            if (range) {
+                this.setState({ levelRange: range });
+            }
+        } catch {
+            // ignore — keeps the 0-100 fallback
+        }
+    }
+
+    // --- State change handlers ---
+
+    private onPowerChange = (_id: string, state: ioBroker.State): void => {
+        const val = state.val;
+        // The live value is the surest signal of the datapoint's actual type — a `getObject()` that
+        // fails or hasn't resolved yet must not leave a numeric POWER datapoint written as a boolean.
+        if (typeof val === 'number' || typeof val === 'boolean') {
+            this.powerIsNumber = typeof val === 'number';
+            this.powerTypeKnown = true;
+        }
+        const power = typeof val === 'number' || typeof val === 'boolean' ? val : null;
+        if (power !== this.state.power) {
+            this.setState({ power });
+        }
+    };
+
+    private onLevelChange = (_id: string, state: ioBroker.State): void => {
+        if (this.levelDragging) {
+            return;
+        }
+        const level = toNumberOrNull(state.val);
+        if (level !== this.state.level) {
+            this.setState({ level });
+        }
+    };
+
+    private onTemperatureChange = (_id: string, state: ioBroker.State): void => {
+        const temperature = toNumberOrNull(state.val);
+        if (temperature !== this.state.temperature) {
+            this.setState({ temperature });
+        }
+    };
+
+    private onPressureChange = (_id: string, state: ioBroker.State): void => {
+        const pressure = toNumberOrNull(state.val);
+        if (pressure !== this.state.pressure) {
+            this.setState({ pressure });
+        }
+    };
+
+    private onFlowChange = (_id: string, state: ioBroker.State): void => {
+        const flow = toNumberOrNull(state.val);
+        if (flow !== this.state.flow) {
+            this.setState({ flow });
+        }
+    };
+
+    // --- Actions ---
+    //
+    // Neither write updates state optimistically: the subscription above reports what the device
+    // actually accepted, and a rejected write must not leave a control showing a value the device
+    // never took. The level slider is the exception during an active drag — it must track the
+    // pointer — which is why it carries its own dragging guard.
+
+    /**
+     * POWER is `boolean|number` in the pattern, so the write has to match the datapoint. Refuses while
+     * the type is unknown rather than writing a value the device would reject.
+     */
+    private togglePower = (): void => {
+        if (!this.powerId || !this.powerTypeKnown) {
+            return;
+        }
+        const isOn = !!this.state.power;
+        const next: boolean | number = this.powerIsNumber ? (isOn ? 0 : 1) : !isOn;
+        void this.setValue(this.powerId, next);
+    };
+
+    private setLevel = (value: number): void => {
+        if (this.levelId) {
+            void this.setValue(this.levelId, clampToRange(value, this.state.levelRange));
+        }
+    };
+
+    /** True once the device is known to be off — not merely "hasn't reported power yet" */
+    private isPoweredOff(): boolean {
+        return !!this.powerId && this.state.power != null && !this.state.power;
+    }
+
+    /** Close the control dialog, ending any in-progress drag so a stalled gesture cannot mute the tile forever */
+    private closeDialog = (): void => {
+        this.levelDragging = false;
+        this.setState({ dialogOpen: false });
+    };
+
+    // --- Tile overrides ---
+
+    protected isTileActive(): boolean {
+        return !!this.state.power;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    protected hasTileAction(): boolean {
+        return true;
+    }
+
+    /**
+     * Openable even for a read-only widget, unlike the base rule.
+     *
+     * The dialog is the only place a pump's temperature, pressure and flow are shown, and those are
+     * readings rather than controls — withholding them from someone who may not operate the pump
+     * hides information they are allowed to see. Every control inside is disabled independently.
+     */
+    protected tileClickable(): boolean {
+        return this.hasTileAction();
+    }
+
+    protected onTileClick(): void {
+        this.setState({ dialogOpen: true });
+    }
+
+    protected renderTileIcon(): React.JSX.Element {
+        const baseIcon = super.renderTileIcon();
+        if (baseIcon) {
+            return baseIcon;
+        }
+        const isActive = this.isTileActive();
+        return (
+            <Plumbing
+                sx={{
+                    color: isActive
+                        ? this.getAccentColor() || ACCENT_COLOR
+                        : this.getInactiveColor() || 'text.disabled',
+                    transition: 'color 0.25s ease',
+                }}
+            />
+        );
+    }
+
+    /**
+     * Compact tile shows this only at 1x1; every other size shows {@link renderTileAction} instead,
+     * which renders the same information — showing both at once would print it twice on one tile.
+     */
+    protected renderTileStatus(): React.JSX.Element | null {
+        const size = this.props.settings?.size || '1x1';
+        if (size !== '1x1') {
+            return null;
+        }
+        return this.renderStatusContent('caption');
+    }
+
+    protected renderTileAction(): React.JSX.Element | null {
+        return this.renderStatusContent('body2');
+    }
+
+    private renderStatusContent(variant: 'caption' | 'body2'): React.JSX.Element | null {
+        const { power, level, levelUnit } = this.state;
+        const poweredOff = this.isPoweredOff();
+        const hasAnyReading = power != null || level != null;
+
+        if (!hasAnyReading) {
+            return (
+                <Typography
+                    variant={variant}
+                    sx={{ color: 'text.disabled' }}
+                >
+                    {I18n.t('wm_No data')}
+                </Typography>
+            );
+        }
+
+        return (
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                <Typography
+                    variant={variant}
+                    sx={{ fontWeight: 500, color: poweredOff ? 'text.disabled' : 'text.secondary' }}
+                >
+                    {power == null ? '—' : power ? I18n.t('wm_On') : I18n.t('wm_Off')}
+                </Typography>
+                {level != null ? (
+                    <Typography
+                        variant={variant}
+                        sx={{ color: 'text.secondary' }}
+                    >
+                        {this.formatLevel(level)}
+                        {levelUnit ? ` ${levelUnit}` : ''}
+                    </Typography>
+                ) : null}
+            </Box>
+        );
+    }
+
+    /** A step below 1 (a fractional stage scale) needs a decimal, or its steps all round to the same integer */
+    private levelDecimals(): number {
+        return this.state.levelRange.step > 0 && this.state.levelRange.step < 1 ? 1 : 0;
+    }
+
+    private formatLevel(value: number): string {
+        return formatFloat(value, this.levelDecimals(), this.props.stateContext.isFloatComma);
+    }
+
+    protected getHistoryIds(): { id: string; color: string }[] {
+        return this.levelId ? [{ id: this.levelId, color: ACCENT_COLOR }] : [];
+    }
+
+    protected getChartUnit(): string | undefined {
+        return this.levelId ? this.state.levelUnit || undefined : undefined;
+    }
+
+    // --- Control dialog ---
+
+    private renderReadingRow(
+        icon: React.JSX.Element,
+        label: string,
+        value: number | null,
+        unit: string,
+    ): React.JSX.Element {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: 0.5 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, color: 'text.secondary' }}>
+                    {icon}
+                    <Typography variant="body2">{label}</Typography>
+                </Box>
+                <Typography
+                    variant="body2"
+                    sx={{ fontWeight: 600 }}
+                >
+                    {value == null
+                        ? '—'
+                        : `${formatFloat(value, 1, this.props.stateContext.isFloatComma)}${unit ? ` ${unit}` : ''}`}
+                </Typography>
+            </Box>
+        );
+    }
+
+    private renderControlDialog(): React.JSX.Element | null {
+        if (!this.state.dialogOpen) {
+            return null;
+        }
+
+        const {
+            name,
+            power,
+            level,
+            levelRange,
+            levelUnit,
+            temperature,
+            temperatureUnit,
+            pressure,
+            pressureUnit,
+            flow,
+            flowUnit,
+        } = this.state;
+        const hasReadings = !!(this.temperatureId || this.pressureId || this.flowId);
+        const dimmedSx = this.isPoweredOff() ? { opacity: 0.5, transition: 'opacity 0.25s ease' } : {};
+
+        return (
+            <Dialog
+                open
+                onClose={this.closeDialog}
+                maxWidth="xs"
+                fullWidth
+                slotProps={{ paper: { sx: { borderRadius: '24px' } } }}
+            >
+                <DialogContent sx={{ p: 3, pt: 2, position: 'relative' }}>
+                    <IconButton
+                        size="small"
+                        onClick={this.closeDialog}
+                        sx={{ position: 'absolute', top: 8, right: 8 }}
+                    >
+                        <Close fontSize="small" />
+                    </IconButton>
+
+                    <Typography
+                        variant="h6"
+                        sx={{ fontWeight: 600, mb: 2, pr: 4 }}
+                    >
+                        {this.props.settings?.name || name || '...'}
+                    </Typography>
+
+                    <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2, ...dimmedSx }}>
+                        <Box sx={{ fontSize: 64, '& .MuiSvgIcon-root': { fontSize: 'inherit !important' } }}>
+                            {this.renderTileIcon()}
+                        </Box>
+                    </Box>
+
+                    {this.powerId ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+                            <Button
+                                variant={power ? 'contained' : 'outlined'}
+                                color={power ? 'success' : 'inherit'}
+                                startIcon={<PowerSettingsNew />}
+                                disabled={this.isReadOnly || !this.powerTypeKnown}
+                                onClick={this.togglePower}
+                                size="small"
+                                sx={{ textTransform: 'none', borderRadius: '20px' }}
+                            >
+                                {I18n.t('wm_On/Off')}
+                            </Button>
+                        </Box>
+                    ) : null}
+
+                    {this.levelId ? (
+                        <Box sx={{ mb: hasReadings ? 2 : 0 }}>
+                            <Typography
+                                variant="body2"
+                                sx={{ fontWeight: 600, mb: 0.75, color: 'text.secondary' }}
+                            >
+                                <SpeedIcon sx={{ fontSize: 16, verticalAlign: 'middle', mr: 0.5 }} />
+                                {I18n.t('wm_Level')}
+                            </Typography>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, ...dimmedSx }}>
+                                <Slider
+                                    disabled={this.isReadOnly}
+                                    value={level ?? levelRange.min}
+                                    min={levelRange.min}
+                                    max={levelRange.max}
+                                    step={levelRange.step}
+                                    valueLabelDisplay="auto"
+                                    onChange={(_e, value) => {
+                                        if (!Array.isArray(value)) {
+                                            this.levelDragging = true;
+                                            this.setState({ level: value });
+                                        }
+                                    }}
+                                    onChangeCommitted={(_e, value) => {
+                                        this.levelDragging = false;
+                                        if (!Array.isArray(value)) {
+                                            this.setLevel(value);
+                                        }
+                                    }}
+                                    sx={{ flex: 1 }}
+                                />
+                                <Typography
+                                    variant="body2"
+                                    sx={{ color: 'text.secondary', minWidth: 42, textAlign: 'right' }}
+                                >
+                                    {level == null
+                                        ? '—'
+                                        : `${this.formatLevel(level)}${levelUnit ? ` ${levelUnit}` : ''}`}
+                                </Typography>
+                            </Box>
+                        </Box>
+                    ) : null}
+
+                    {hasReadings ? (
+                        <Box
+                            sx={{
+                                pt: this.levelId ? 1 : 0,
+                                borderTop: this.levelId ? '1px solid' : 'none',
+                                borderColor: 'divider',
+                            }}
+                        >
+                            {this.temperatureId
+                                ? this.renderReadingRow(
+                                      <Thermostat sx={{ fontSize: 16 }} />,
+                                      I18n.t('wm_Temperature'),
+                                      temperature,
+                                      temperatureUnit,
+                                  )
+                                : null}
+                            {this.pressureId
+                                ? this.renderReadingRow(
+                                      <Compress sx={{ fontSize: 16 }} />,
+                                      I18n.t('wm_Pressure'),
+                                      pressure,
+                                      pressureUnit,
+                                  )
+                                : null}
+                            {this.flowId
+                                ? this.renderReadingRow(
+                                      <Waves sx={{ fontSize: 16 }} />,
+                                      I18n.t('wm_Flow'),
+                                      flow,
+                                      flowUnit,
+                                  )
+                                : null}
+                        </Box>
+                    ) : null}
+                </DialogContent>
+            </Dialog>
+        );
+    }
+
+    render(): React.JSX.Element {
+        return (
+            <>
+                {super.render()}
+                {this.renderControlDialog()}
+            </>
+        );
+    }
+}
+
+export default WidgetPump;

--- a/src-admin/src/WidgetsManager/Widgets/climate.ts
+++ b/src-admin/src/WidgetsManager/Widgets/climate.ts
@@ -194,6 +194,31 @@ export function rangeFromCommon(
     return { min, max, step: step > 0 ? step : fallback.step };
 }
 
+/**
+ * A device-declared numeric range, trusted only once both bounds are explicit.
+ *
+ * Unlike {@link rangeFromCommon}, this takes no fallback to fill in a missing bound: a datapoint
+ * that declares only one, or neither, has said nothing about its scale, and a pattern's
+ * `defaultUnit` (e.g. '%') is not a declaration either — trusting it would silently cap a device
+ * whose native range is wider (an rpm speed pinned to 0-100). Used by widgets whose control has no
+ * setpoint concept of its own (fan speed, pump level).
+ *
+ * @param common The datapoint's common section
+ * @returns The declared range, or null until both bounds are known
+ */
+export function explicitRangeFromCommon(common: ioBroker.StateCommon | undefined): SetpointRange | null {
+    if (!common || common.min == null || common.max == null) {
+        return null;
+    }
+    const min = Number(common.min);
+    const max = Number(common.max);
+    const step = common.step != null ? Number(common.step) : 1;
+    if (isNaN(min) || isNaN(max) || max <= min) {
+        return null;
+    }
+    return { min, max, step: step > 0 ? step : 1 };
+}
+
 /** What one setpoint datapoint declares about itself */
 export interface SetpointMeta {
     range: SetpointRange | null;

--- a/src-admin/src/WidgetsManager/Widgets/index.ts
+++ b/src-admin/src/WidgetsManager/Widgets/index.ts
@@ -30,6 +30,7 @@ export { WidgetLocation } from './Location';
 export { WidgetLock } from './Lock';
 export { WidgetMediaPlayer } from './MediaPlayer';
 export { WidgetMotion } from './Motion';
+export { WidgetPump } from './Pump';
 export { WidgetSlider } from './Slider';
 export { WidgetSwitch } from './Switch';
 export { WidgetTank } from './Tank';

--- a/src-admin/src/WidgetsManager/i18n/de.json
+++ b/src-admin/src/WidgetsManager/i18n/de.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Fenster offen",
     "wm_Fan": "Ventilator",
     "wm_Air purifier": "Luftreiniger",
-    "wm_Electricity": "Stromzähler"
+    "wm_Electricity": "Stromzähler",
+    "wm_Pump": "Pumpe",
+    "wm_Level": "Stufe",
+    "wm_Temperature": "Temperatur",
+    "wm_Flow": "Durchfluss"
 }

--- a/src-admin/src/WidgetsManager/i18n/de.json
+++ b/src-admin/src/WidgetsManager/i18n/de.json
@@ -246,7 +246,7 @@
     "wm_Presence_desc": "Zeigt wer zuhause ist mit Avatar und letzter Statusänderung",
     "wm_Press": "Drücken",
     "wm_Pressed": "Gedrückt",
-    "wm_Pressure": "Luftdruck",
+    "wm_Pressure": "Druck",
     "wm_Producers": "Erzeuger",
     "wm_Producers help": "Erzeuger-States hinzufügen (Solar, Wind, Netz, …). Jede Zeile wird auf der kleinen Kachel summiert.",
     "wm_Progress": "Fortschritt",

--- a/src-admin/src/WidgetsManager/i18n/en.json
+++ b/src-admin/src/WidgetsManager/i18n/en.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Window open",
     "wm_Fan": "Fan",
     "wm_Air purifier": "Air purifier",
-    "wm_Electricity": "Electricity"
+    "wm_Electricity": "Electricity",
+    "wm_Pump": "Pump",
+    "wm_Level": "Level",
+    "wm_Temperature": "Temperature",
+    "wm_Flow": "Flow"
 }

--- a/src-admin/src/WidgetsManager/i18n/es.json
+++ b/src-admin/src/WidgetsManager/i18n/es.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Ventana abierta",
     "wm_Fan": "Ventilador",
     "wm_Air purifier": "Purificador de aire",
-    "wm_Electricity": "Electricidad"
+    "wm_Electricity": "Electricidad",
+    "wm_Pump": "Bomba",
+    "wm_Level": "Nivel",
+    "wm_Temperature": "Temperatura",
+    "wm_Flow": "Caudal"
 }

--- a/src-admin/src/WidgetsManager/i18n/fr.json
+++ b/src-admin/src/WidgetsManager/i18n/fr.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Fenêtre ouverte",
     "wm_Fan": "Ventilateur",
     "wm_Air purifier": "Purificateur d'air",
-    "wm_Electricity": "Électricité"
+    "wm_Electricity": "Électricité",
+    "wm_Pump": "Pompe",
+    "wm_Level": "Niveau",
+    "wm_Temperature": "Température",
+    "wm_Flow": "Débit"
 }

--- a/src-admin/src/WidgetsManager/i18n/it.json
+++ b/src-admin/src/WidgetsManager/i18n/it.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Finestra aperta",
     "wm_Fan": "Ventilatore",
     "wm_Air purifier": "Purificatore d'aria",
-    "wm_Electricity": "Elettricità"
+    "wm_Electricity": "Elettricità",
+    "wm_Pump": "Pompa",
+    "wm_Level": "Livello",
+    "wm_Temperature": "Temperatura",
+    "wm_Flow": "Portata"
 }

--- a/src-admin/src/WidgetsManager/i18n/nl.json
+++ b/src-admin/src/WidgetsManager/i18n/nl.json
@@ -246,7 +246,7 @@
     "wm_Presence_desc": "Toont wie thuis is met avatar en laatste activiteit",
     "wm_Press": "Indrukken",
     "wm_Pressed": "Ingedrukt",
-    "wm_Pressure": "Luchtdruk",
+    "wm_Pressure": "Druk",
     "wm_Producers": "Producenten",
     "wm_Producers help": "Voeg producerende states toe (zon, wind, net, etc.). De som van de rijen verschijnt op de kleine tegel.",
     "wm_Progress": "Voortgang",

--- a/src-admin/src/WidgetsManager/i18n/nl.json
+++ b/src-admin/src/WidgetsManager/i18n/nl.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Raam open",
     "wm_Fan": "Ventilator",
     "wm_Air purifier": "Luchtreiniger",
-    "wm_Electricity": "Elektriciteit"
+    "wm_Electricity": "Elektriciteit",
+    "wm_Pump": "Pomp",
+    "wm_Level": "Niveau",
+    "wm_Temperature": "Temperatuur",
+    "wm_Flow": "Doorstroming"
 }

--- a/src-admin/src/WidgetsManager/i18n/pl.json
+++ b/src-admin/src/WidgetsManager/i18n/pl.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Okno otwarte",
     "wm_Fan": "Wentylator",
     "wm_Air purifier": "Oczyszczacz powietrza",
-    "wm_Electricity": "Elektryczność"
+    "wm_Electricity": "Elektryczność",
+    "wm_Pump": "Pompa",
+    "wm_Level": "Poziom",
+    "wm_Temperature": "Temperatura",
+    "wm_Flow": "Przepływ"
 }

--- a/src-admin/src/WidgetsManager/i18n/pt.json
+++ b/src-admin/src/WidgetsManager/i18n/pt.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Janela aberta",
     "wm_Fan": "Ventilador",
     "wm_Air purifier": "Purificador de ar",
-    "wm_Electricity": "Eletricidade"
+    "wm_Electricity": "Eletricidade",
+    "wm_Pump": "Bomba",
+    "wm_Level": "Nível",
+    "wm_Temperature": "Temperatura",
+    "wm_Flow": "Vazão"
 }

--- a/src-admin/src/WidgetsManager/i18n/ru.json
+++ b/src-admin/src/WidgetsManager/i18n/ru.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Окно открыто",
     "wm_Fan": "Вентилятор",
     "wm_Air purifier": "Очиститель воздуха",
-    "wm_Electricity": "Электричество"
+    "wm_Electricity": "Электричество",
+    "wm_Pump": "Насос",
+    "wm_Level": "Уровень",
+    "wm_Temperature": "Температура",
+    "wm_Flow": "Расход"
 }

--- a/src-admin/src/WidgetsManager/i18n/uk.json
+++ b/src-admin/src/WidgetsManager/i18n/uk.json
@@ -576,5 +576,9 @@
     "wm_Window open": "Вікно відкрито",
     "wm_Fan": "Вентилятор",
     "wm_Air purifier": "Очищувач повітря",
-    "wm_Electricity": "Електрика"
+    "wm_Electricity": "Електрика",
+    "wm_Pump": "Насос",
+    "wm_Level": "Рівень",
+    "wm_Temperature": "Температура",
+    "wm_Flow": "Витрата"
 }

--- a/src-admin/src/WidgetsManager/i18n/zh-cn.json
+++ b/src-admin/src/WidgetsManager/i18n/zh-cn.json
@@ -576,5 +576,9 @@
     "wm_Window open": "窗户已打开",
     "wm_Fan": "风扇",
     "wm_Air purifier": "空气净化器",
-    "wm_Electricity": "电量"
+    "wm_Electricity": "电量",
+    "wm_Pump": "水泵",
+    "wm_Level": "档位",
+    "wm_Temperature": "温度",
+    "wm_Flow": "流量"
 }

--- a/src-admin/src/WidgetsManager/i18n/zh-cn.json
+++ b/src-admin/src/WidgetsManager/i18n/zh-cn.json
@@ -246,7 +246,7 @@
     "wm_Presence_desc": "显示谁在家，带头像和最后活动时间",
     "wm_Press": "按下",
     "wm_Pressed": "已按下",
-    "wm_Pressure": "气压",
+    "wm_Pressure": "压力",
     "wm_Producers": "生产者",
     "wm_Producers help": "添加生产者状态（太阳能、风、电网等）。每行的值会在小图块上累加。",
     "wm_Progress": "进度",


### PR DESCRIPTION
The last of the nine device types type-detector 6.0.0 added that still needed a tile of its own. Two
commits, source only, based on master.

`pump` has rendered a **"widget type not supported"** placeholder since the bump — it never even had a
routing arm. It is a control, and #661 declined to park controls on a read-only value tile, which was
right: a tile that cannot operate the device misrepresents it.

## What a pump actually declares

    POWER        boolean|number  switch.pump       REQUIRED  write
    LEVEL        number          level.pump                  write   defaultUnit=%
    TEMPERATURE  number          value.temperature                   read-only
    PRESSURE     number          value.pressure                      read-only
    FLOW         number          value.flow                          read-only
    + the five electricity readings, + the usual indicators

**Only POWER is required**, so the tile has to work for a pump that has nothing but an on/off switch.
Verified against the real detector for each shape:

```
power only (the minimum)     [pump]  POWER
power numeric + level        [pump]  POWER, LEVEL
level with no declared range [pump]  POWER, LEVEL
all three readings           [pump]  POWER, TEMPERATURE, PRESSURE, FLOW
pump + electricity           [pump]  POWER, ELECTRIC_POWER
```

## Where the readings go, and why the dialog opens read-only

Temperature, pressure and flow are shown in the widget's dialog rather than on the tile face. A 1x1
tile has no room for five values, and a tile whose face changes with its size is a tile a user has to
relearn.

That dialog **opens even when the widget is read-only**, which the base rule (`tileClickable()` is
`hasTileAction() && !isReadOnly`) would prevent. Those three are readings, not controls: withholding
them from someone who may not operate the pump hides information they are allowed to see. Every control
inside is disabled independently and `setValue()` refuses regardless, and the flag only gates the
ripple, the cursor and the click handler — no write path.

## Type and scale discipline

`POWER` is `boolean|number`, so the type belongs to the datapoint: it comes from the object, or from the
first live value when the object cannot be read, and the switch **stays disabled until one of the two
has said which it is** rather than guessing.

`LEVEL`'s unit comes from the state itself, and its range only from bounds the datapoint actually
declares. A pump reporting a 0–5 stage or an rpm-like scale must not be silently capped at 0–100 on
every write, and `defaultUnit: '%'` is a suggestion, not a declaration. Fractional steps show a decimal,
so a 0–5/step-0.5 pump does not round every half stage to the same integer.

Nothing writes outside `setValue()`, no discrete control updates optimistically, and the level slider
carries a drag guard so a device echo cannot fight the pointer.

## One helper, not three copies

`explicitRangeFromCommon` moves out of `FanBase` into `climate.ts`, beside `rangeFromCommon` — which
fills a missing bound from a fallback and is the wrong tool for a control with no setpoint concept of
its own. The contrast between the two is the part worth documenting once; both callers now share the one
definition, and the review confirmed the moved function is character-for-character identical and that
nothing else in `climate.ts` changed meaning, so the thermostat and air-conditioner are unaffected.

## Second commit: two gaps this exposed in `FanBase`

Both were found by writing the pump and confirmed in the shared fan/air-purifier base:

- **A drag ended by pointer-cancel froze the tile.** The slider guards were only cleared by a commit
  event, so a drag interrupted another way left the widget ignoring the device's own updates for as
  long as the tile lived. Closing the dialog now clears them.
- **A read-only fan or air purifier could not open its dialog either**, for the same reason and with the
  same consequence for its readings.

Also in that commit: `wm_Pressure` read as *barometric* pressure in German, Dutch and Chinese
(`Luftdruck`, `Luchtdruk`, `气压`). The key labels a pump's mechanical pressure and the `pressure`
device type's reading as well, so all three become the general term.

## Every one of the nine now has its own tile

```
contact  coAlarm  pressure  flow      #665
fan      airPurifier                  #667
electricity                           #668
pump                                  this PR
airQuality                            info tile, deliberately, until its own change
```

The info-tile stopgap the bump shipped with is retired except for `airQuality`.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, full `npm run build`,
`test:unit` (77) and `test:package` (47). i18n at 582 keys with identical sets across all 11 files.

An independent adversarial review covered eight areas and found one thing — the read-only dialog above,
which is fixed here for both widgets. It separately verified the `FanBase`/`climate.ts` move for
regressions, the range edge cases (one bound, inverted, non-numeric, zero step all fall back rather than
mis-clamp), subscribe/unsubscribe symmetry, that nothing prints twice at any of the four sizes, and that
the unit comes from the object rather than the pattern.

## Follow-ups

- **`airQuality`** — 34 states: `AQI` plus eleven pollutants each paired with a `*_LEVEL` enum
  (`UNKNOWN/LOW/MEDIUM/HIGH/CRITICAL`), plus pressure, temperature and humidity. The enums are the
  design: they turn eleven raw concentrations into something readable at a glance. Its own PR.
- `WidgetAirCondition` could adopt `FanBase`, and `Illuminance`/`Humidity`/`Temperature` could adopt
  `SingleValueSensorBase`. Both are retro-fits of shipping widgets.
- "POWER toggle + percentage slider" now exists in `Dimmer`, `FanBase` and `Pump`; a shared base for it
  is worth considering once `airQuality` is done.
- **[adapter-react-v5#123](https://github.com/ioBroker/adapter-react-v5/issues/123)** — still no icon or
  `type-*` name in gui-components for any of the nine new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
