### PR TITLE
feat(widgets): an air-quality tile that ranks what it measures

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "build": "npm run build:dm-widgets && npm run build:backend && node tasks",
         "lint": "eslint -c eslint.config.mjs && cd src-admin && npm run lint && cd ../packages/dm-widgets && npm run lint",
         "test:package": "mocha test/package.test.js --exit",
-        "test:unit": "mocha test/acl.test.js test/climate.test.js test/commonStates.test.js --exit",
+        "test:unit": "mocha test/acl.test.js test/climate.test.js test/commonStates.test.js test/airQuality.test.js --exit",
         "test:integration": "mocha test/testAdapter.gui.test.js --exit",
         "release": "release-script",
         "release-patch": "release-script patch --yes",

--- a/src-admin/src/WidgetsManager/Category.tsx
+++ b/src-admin/src/WidgetsManager/Category.tsx
@@ -72,6 +72,7 @@ import {
     WidgetCamera,
     WidgetAirCondition,
     WidgetAirPurifier,
+    WidgetAirQuality,
     WidgetWarning,
     WidgetLock,
     WidgetCoAlarm,
@@ -2234,9 +2235,7 @@ export default class Category extends Component<CategoryProps, CategoryState> {
         } else if (type === Types.electricity) {
             Widget = WidgetElectricity;
         } else if (type === Types.airQuality) {
-            // Split out of `info` by type-detector 6.0.0 and rendered as an info tile before, so it
-            // keeps that tile until it gets the purpose-built one its 29 states deserve.
-            Widget = WidgetInfoWidget;
+            Widget = WidgetAirQuality;
         } else if (type === Types.lock) {
             Widget = WidgetLock;
         } else if (type === Types.door) {

--- a/src-admin/src/WidgetsManager/Widgets/AirQuality.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/AirQuality.tsx
@@ -1,0 +1,725 @@
+import React from 'react';
+import { Box, Button, Dialog, DialogContent, IconButton, Tooltip, Typography } from '@mui/material';
+import { Air, Close, PowerSettingsNew } from '@mui/icons-material';
+import { I18n } from '@iobroker/gui-components';
+import type { ConfigItemPanel } from '@iobroker/json-config';
+
+import WidgetGeneric, {
+    formatFloat,
+    toNumberOrNull,
+    type WidgetGenericProps,
+    type WidgetGenericState,
+} from './Generic';
+import { parseCommonStates } from './commonStates';
+import {
+    knownLabelKey,
+    POLLUTANT_NAMES,
+    rankPollutants,
+    resolveEnumDisplay,
+    type PollutantName,
+    type PollutantRow,
+} from './airQualityUtils';
+import { hideBaseFields } from '../configUtils';
+
+/** Chemical symbols, not translated (matches the pattern's own role ids one-to-one) */
+const POLLUTANT_SYMBOLS: Record<PollutantName, string> = {
+    CO2: 'CO₂',
+    TVOC: 'TVOC',
+    PM1: 'PM1',
+    PM25: 'PM2.5',
+    PM10: 'PM10',
+    CO: 'CO',
+    NO2: 'NO₂',
+    O3: 'O₃',
+    CH2O: 'CH₂O',
+    RN: 'Rn',
+    SO2: 'SO₂',
+};
+
+/** 7-value AQI band scale — used on the tile face and in the dialog headline, nowhere else */
+const AQI_BAND_COLORS: Record<number, string> = {
+    0: '#9e9e9e', // UNKNOWN
+    1: '#4caf50', // GOOD
+    2: '#8bc34a', // FAIR
+    3: '#ffc107', // MODERATE
+    4: '#ff9800', // POOR
+    5: '#f4511e', // VERY_POOR
+    6: '#c62828', // EXTREMELY_POOR
+};
+
+const AQI_LABEL_KEYS: Record<string, string> = {
+    UNKNOWN: 'wm_aqi_unknown',
+    GOOD: 'wm_aqi_good',
+    FAIR: 'wm_aqi_fair',
+    MODERATE: 'wm_aqi_moderate',
+    POOR: 'wm_aqi_poor',
+    VERY_POOR: 'wm_aqi_very_poor',
+    EXTREMELY_POOR: 'wm_aqi_extremely_poor',
+};
+
+/** 5-value LEVEL scale shared by all eleven pollutants — a separate scale from the AQI bands above */
+const LEVEL_COLORS: Record<number, string> = {
+    0: '#9e9e9e', // UNKNOWN
+    1: '#4caf50', // LOW
+    2: '#ffc107', // MEDIUM
+    3: '#ff9800', // HIGH
+    4: '#c62828', // CRITICAL
+};
+
+const LEVEL_LABEL_KEYS: Record<string, string> = {
+    UNKNOWN: 'wm_level_unknown',
+    LOW: 'wm_level_low',
+    MEDIUM: 'wm_level_medium',
+    HIGH: 'wm_level_high',
+    CRITICAL: 'wm_level_critical',
+};
+
+/**
+ * Fallback for a `*_LEVEL` datapoint that declares no `common.states` of its own (see
+ * `loadLevelStates`): every `*_LEVEL` pattern declares this exact enum, so — unlike AQI, which a
+ * device may report on a completely different scale — the numeric index itself is always trustworthy
+ * for ranking and colouring, whatever label ends up being shown for it.
+ */
+/** Only what is left when the pattern itself declares no list for a LEVEL state */
+const LEVEL_STATES_FALLBACK: Record<string, string> = {
+    0: 'UNKNOWN',
+    1: 'LOW',
+    2: 'MEDIUM',
+    3: 'HIGH',
+    4: 'CRITICAL',
+};
+
+const HISTORY_COLOR = '#4db6ac';
+
+interface PollutantMeta {
+    valueId: string | null;
+    levelId: string | null;
+    unit: string;
+}
+
+interface DisplayRow {
+    key: PollutantName;
+    symbol: string;
+    valueText: string;
+    levelText: string;
+    levelColor: string | undefined;
+}
+
+interface WidgetAirQualityState extends WidgetGenericState {
+    /** Normally a number, but see `resolveEnumDisplay` for why a reported string must not be dropped */
+    aqi: number | string | null;
+    /** Parsed `common.states` of the AQI datapoint itself, empty when it declares none */
+    aqiDeviceStates: Record<string, string>;
+    power: boolean | null;
+    pollutantValues: Partial<Record<PollutantName, number | null>>;
+    pollutantLevels: Partial<Record<PollutantName, number | string | null>>;
+    /** Parsed `common.states` of each `*_LEVEL` datapoint itself, only present when it declares one */
+    levelDeviceStates: Partial<Record<PollutantName, Record<string, string>>>;
+    actual: number | null;
+    humidity: number | null;
+    pressure: number | null;
+    dialogOpen: boolean;
+}
+
+export class WidgetAirQuality extends WidgetGeneric<WidgetAirQualityState> {
+    static override getConfigSchema(): { name: string; schema: ConfigItemPanel } {
+        return {
+            name: 'wm_Air quality',
+            schema: { type: 'panel', items: { ...hideBaseFields('colorActive', 'color') } },
+        };
+    }
+
+    private readonly aqiId: string | null;
+    private readonly aqiUnit: string;
+    /** `defaultStates` of the detected AQI state — fallback for a datapoint with no `common.states` */
+    private readonly aqiPatternStates: Record<string, string>;
+    /** The LEVEL enum as the pattern declares it, read from the states rather than assumed */
+    private levelPatternStates: Record<string, string> = LEVEL_STATES_FALLBACK;
+    private readonly powerId: string | null;
+    private readonly pollutantMeta: Partial<Record<PollutantName, PollutantMeta>> = {};
+    private readonly valueIdToName: Record<string, PollutantName> = {};
+    private readonly levelIdToName: Record<string, PollutantName> = {};
+    private readonly actualId: string | null;
+    private readonly actualUnit: string;
+    private readonly humidityId: string | null;
+    private readonly humidityUnit: string;
+    private readonly pressureId: string | null;
+    private readonly pressureUnit: string;
+
+    constructor(props: WidgetGenericProps) {
+        super(props);
+        const states = props.widget.control.states;
+
+        const aqiState = states.find(s => s.name === 'AQI' && s.id);
+        this.aqiId = aqiState?.id ?? null;
+        this.aqiUnit = aqiState?.unit || '';
+        this.aqiPatternStates = aqiState?.defaultStates ? parseCommonStates(aqiState.defaultStates) : {};
+
+        this.powerId = states.find(s => s.name === 'POWER' && s.id)?.id ?? null;
+
+        for (const name of POLLUTANT_NAMES) {
+            const valueState = states.find(s => s.name === name && s.id);
+            const levelState = states.find(s => s.name === `${name}_LEVEL` && s.id);
+            if (levelState?.defaultStates && this.levelPatternStates === LEVEL_STATES_FALLBACK) {
+                // Every LEVEL entry declares the same enum, so the first one carrying it speaks for all
+                this.levelPatternStates = parseCommonStates(levelState.defaultStates);
+            }
+            this.pollutantMeta[name] = {
+                valueId: valueState?.id ?? null,
+                levelId: levelState?.id ?? null,
+                unit: valueState?.unit || '',
+            };
+            if (valueState?.id) {
+                this.valueIdToName[valueState.id] = name;
+            }
+            if (levelState?.id) {
+                this.levelIdToName[levelState.id] = name;
+            }
+        }
+
+        const actualState = states.find(s => s.name === 'ACTUAL' && s.id);
+        this.actualId = actualState?.id ?? null;
+        this.actualUnit = actualState?.unit || '';
+
+        const humidityState = states.find(s => s.name === 'HUMIDITY' && s.id);
+        this.humidityId = humidityState?.id ?? null;
+        this.humidityUnit = humidityState?.unit || '';
+
+        const pressureState = states.find(s => s.name === 'PRESSURE' && s.id);
+        this.pressureId = pressureState?.id ?? null;
+        this.pressureUnit = pressureState?.unit || '';
+
+        this.state = {
+            ...this.state,
+            aqi: null,
+            aqiDeviceStates: {},
+            power: null,
+            pollutantValues: {},
+            pollutantLevels: {},
+            levelDeviceStates: {},
+            actual: null,
+            humidity: null,
+            pressure: null,
+            dialogOpen: false,
+        };
+    }
+
+    componentDidMount(): void {
+        super.componentDidMount();
+        if (this.aqiId) {
+            this.props.stateContext.getState(this.aqiId, this.onAqiChange);
+            void this.loadAqiStates();
+        }
+        if (this.powerId) {
+            this.props.stateContext.getState(this.powerId, this.onPowerChange);
+        }
+        for (const id of Object.keys(this.valueIdToName)) {
+            this.props.stateContext.getState(id, this.onPollutantValueChange);
+        }
+        for (const id of Object.keys(this.levelIdToName)) {
+            this.props.stateContext.getState(id, this.onPollutantLevelChange);
+        }
+        void this.loadLevelStates();
+        if (this.actualId) {
+            this.props.stateContext.getState(this.actualId, this.onActualChange);
+        }
+        if (this.humidityId) {
+            this.props.stateContext.getState(this.humidityId, this.onHumidityChange);
+        }
+        if (this.pressureId) {
+            this.props.stateContext.getState(this.pressureId, this.onPressureChange);
+        }
+    }
+
+    componentWillUnmount(): void {
+        super.componentWillUnmount();
+        if (this.aqiId) {
+            this.props.stateContext.removeState(this.aqiId, this.onAqiChange);
+        }
+        if (this.powerId) {
+            this.props.stateContext.removeState(this.powerId, this.onPowerChange);
+        }
+        for (const id of Object.keys(this.valueIdToName)) {
+            this.props.stateContext.removeState(id, this.onPollutantValueChange);
+        }
+        for (const id of Object.keys(this.levelIdToName)) {
+            this.props.stateContext.removeState(id, this.onPollutantLevelChange);
+        }
+        if (this.actualId) {
+            this.props.stateContext.removeState(this.actualId, this.onActualChange);
+        }
+        if (this.humidityId) {
+            this.props.stateContext.removeState(this.humidityId, this.onHumidityChange);
+        }
+        if (this.pressureId) {
+            this.props.stateContext.removeState(this.pressureId, this.onPressureChange);
+        }
+    }
+
+    private async loadAqiStates(): Promise<void> {
+        if (!this.aqiId) {
+            return;
+        }
+        try {
+            const obj = (await this.props.stateContext.getSocket().getObject(this.aqiId)) as
+                | ioBroker.StateObject
+                | null
+                | undefined;
+            const parsed = parseCommonStates(obj?.common?.states);
+            if (Object.keys(parsed).length) {
+                this.setState({ aqiDeviceStates: parsed });
+            }
+        } catch {
+            // Unreadable object: the pattern's own labels, already in state, are what's left
+        }
+    }
+
+    /**
+     * A `*_LEVEL` datapoint's own `common.states` is a device-declared override just like AQI's —
+     * the fixed 0-4 enum in `LEVEL_PATTERN_STATES` is only what's left when a device declares none.
+     */
+    private async loadLevelStates(): Promise<void> {
+        const entries = Object.entries(this.levelIdToName);
+        if (!entries.length) {
+            return;
+        }
+        const results = await Promise.allSettled(
+            entries.map(async ([id, name]) => {
+                const obj = (await this.props.stateContext.getSocket().getObject(id)) as
+                    | ioBroker.StateObject
+                    | null
+                    | undefined;
+                return { name, parsed: parseCommonStates(obj?.common?.states) };
+            }),
+        );
+        const levelDeviceStates: Partial<Record<PollutantName, Record<string, string>>> = {};
+        for (const result of results) {
+            if (result.status === 'fulfilled' && Object.keys(result.value.parsed).length) {
+                levelDeviceStates[result.value.name] = result.value.parsed;
+            }
+        }
+        if (Object.keys(levelDeviceStates).length) {
+            this.setState({ levelDeviceStates });
+        }
+    }
+
+    // --- State change handlers ---
+
+    private onAqiChange = (_id: string, state: ioBroker.State): void => {
+        // AQI indexes a value list, like AirCondition's MODE — a device may report the index as a
+        // string, and `toNumberOrNull` would silently turn that into "no reading".
+        const val = state.val;
+        const aqi = typeof val === 'number' || typeof val === 'string' ? val : null;
+        if (aqi !== this.state.aqi) {
+            this.setState({ aqi });
+        }
+    };
+
+    private onPowerChange = (_id: string, state: ioBroker.State): void => {
+        const power = typeof state.val === 'boolean' ? state.val : null;
+        if (power !== this.state.power) {
+            this.setState({ power });
+        }
+    };
+
+    private onPollutantValueChange = (id: string, state: ioBroker.State): void => {
+        const name = this.valueIdToName[id];
+        if (!name) {
+            return;
+        }
+        const value = toNumberOrNull(state.val);
+        if (this.state.pollutantValues[name] !== value) {
+            this.setState(prev => ({ pollutantValues: { ...prev.pollutantValues, [name]: value } }));
+        }
+    };
+
+    private onPollutantLevelChange = (id: string, state: ioBroker.State): void => {
+        const name = this.levelIdToName[id];
+        if (!name) {
+            return;
+        }
+        const val = state.val;
+        const level = typeof val === 'number' || typeof val === 'string' ? val : null;
+        if (this.state.pollutantLevels[name] !== level) {
+            this.setState(prev => ({ pollutantLevels: { ...prev.pollutantLevels, [name]: level } }));
+        }
+    };
+
+    private onActualChange = (_id: string, state: ioBroker.State): void => {
+        const actual = toNumberOrNull(state.val);
+        if (actual !== this.state.actual) {
+            this.setState({ actual });
+        }
+    };
+
+    private onHumidityChange = (_id: string, state: ioBroker.State): void => {
+        const humidity = toNumberOrNull(state.val);
+        if (humidity !== this.state.humidity) {
+            this.setState({ humidity });
+        }
+    };
+
+    private onPressureChange = (_id: string, state: ioBroker.State): void => {
+        const pressure = toNumberOrNull(state.val);
+        if (pressure !== this.state.pressure) {
+            this.setState({ pressure });
+        }
+    };
+
+    // --- Actions ---
+
+    private togglePower = (): void => {
+        if (!this.powerId) {
+            return;
+        }
+        void this.setValue(this.powerId, !this.state.power);
+    };
+
+    /** True once the device is known to be off — not merely "hasn't reported power yet" */
+    private isPoweredOff(): boolean {
+        return !!this.powerId && this.state.power != null && !this.state.power;
+    }
+
+    // --- Formatting ---
+
+    /** A concentration or ambient reading at the scale the device declared, never inventing a unit */
+    private formatByUnit(value: number | null, unit: string): string {
+        if (value == null) {
+            return '—';
+        }
+        const abs = Math.abs(value);
+        const decimals = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+        const str = formatFloat(value, decimals, this.props.stateContext.isFloatComma);
+        return unit ? `${str} ${unit}` : str;
+    }
+
+    private resolveAqiDisplay(): { text: string; color: string } {
+        const resolved = resolveEnumDisplay(
+            this.state.aqi,
+            this.state.aqiDeviceStates,
+            this.aqiPatternStates,
+            this.aqiUnit,
+            value => formatFloat(value, 0, this.props.stateContext.isFloatComma),
+        );
+        if (resolved.band == null) {
+            return { text: resolved.text, color: this.state.aqi == null ? 'text.disabled' : 'text.primary' };
+        }
+        const key = knownLabelKey(resolved.text, AQI_LABEL_KEYS);
+        if (!key) {
+            // A label was found, but not one of the seven bands this scale means — a device using its
+            // own wording, or a value list on a different scale entirely (e.g. a 0-500 index that
+            // happens to declare states) carries no severity this scale can colour.
+            return { text: resolved.text, color: 'text.primary' };
+        }
+        return { text: I18n.t(key), color: AQI_BAND_COLORS[resolved.band] ?? 'text.primary' };
+    }
+
+    private getPollutantRows(): DisplayRow[] {
+        const rows: PollutantRow[] = POLLUTANT_NAMES.map(name => {
+            const meta = this.pollutantMeta[name];
+            return {
+                name,
+                hasValue: !!meta?.valueId,
+                value: this.state.pollutantValues[name] ?? null,
+                hasLevel: !!meta?.levelId,
+                level: this.state.pollutantLevels[name] ?? null,
+            };
+        }).filter(row => row.hasValue || row.hasLevel);
+
+        return rankPollutants(rows).map(row => {
+            const meta = this.pollutantMeta[row.name];
+            const valueText = row.hasValue ? this.formatByUnit(row.value, meta?.unit || '') : '—';
+
+            let levelText = '—';
+            let levelColor: string | undefined;
+            if (row.hasLevel) {
+                const deviceStates = this.state.levelDeviceStates[row.name] ?? {};
+                const resolved = resolveEnumDisplay(row.level, deviceStates, this.levelPatternStates, '', String);
+                if (resolved.band != null) {
+                    const key = knownLabelKey(resolved.text, LEVEL_LABEL_KEYS);
+                    levelText = key ? I18n.t(key) : resolved.text;
+                    levelColor = LEVEL_COLORS[resolved.band];
+                } else {
+                    levelText = resolved.text;
+                }
+            }
+
+            return { key: row.name, symbol: POLLUTANT_SYMBOLS[row.name], valueText, levelText, levelColor };
+        });
+    }
+
+    // --- Tile ---
+
+    protected getHistoryIds(): { id: string; color: string }[] {
+        return this.aqiId ? [{ id: this.aqiId, color: HISTORY_COLOR }] : [];
+    }
+
+    protected getChartUnit(): string | undefined {
+        return this.aqiUnit || undefined;
+    }
+
+    protected isTileActive(): boolean {
+        return !this.isPoweredOff() && this.state.aqi != null;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    protected hasTileAction(): boolean {
+        return true;
+    }
+
+    /**
+     * Every reading here is read-only, but they are still this device's readings — a user who may
+     * not operate it may still read them, so the dialog opens regardless of ACL. POWER, the one
+     * control inside, stays gated by `disabled={this.isReadOnly}` and by `setValue()` itself.
+     */
+    protected tileClickable(): boolean {
+        return this.hasTileAction();
+    }
+
+    protected onTileClick(): void {
+        this.setState({ dialogOpen: true });
+    }
+
+    protected renderTileIcon(): React.JSX.Element {
+        const baseIcon = super.renderTileIcon();
+        if (baseIcon) {
+            return baseIcon;
+        }
+        const { color } = this.resolveAqiDisplay();
+        return <Air sx={{ color, transition: 'color 0.25s ease' }} />;
+    }
+
+    private renderAqiFace(variant: 'caption' | 'h5'): React.JSX.Element {
+        const { text, color } = this.resolveAqiDisplay();
+        // A reading from a device that is off is the last one it took, not the air now. The dialog
+        // dims the same value for the same reason; a band left at full strength reads as current.
+        const dimmed = this.isPoweredOff() ? { opacity: 0.6 } : undefined;
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ...dimmed }}>
+                {this.isPoweredOff() ? (
+                    <Tooltip title={I18n.t('wm_On/Off')}>
+                        <PowerSettingsNew sx={{ fontSize: variant === 'caption' ? 14 : 16, color: 'text.disabled' }} />
+                    </Tooltip>
+                ) : null}
+                <Typography
+                    variant={variant}
+                    sx={{
+                        fontWeight: variant === 'caption' ? 600 : 700,
+                        ...(variant === 'caption' ? { fontSize: '1.1rem', lineHeight: 1.2 } : {}),
+                        color,
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {text}
+                </Typography>
+            </Box>
+        );
+    }
+
+    protected renderTileStatus(): React.JSX.Element | null {
+        // Every layout but the 1x1 shows the reading through renderTileAction — rendering it here as
+        // well would print it twice on one tile.
+        const size = this.props.settings?.size || '1x1';
+        if (size !== '1x1') {
+            return null;
+        }
+        return this.renderAqiFace('caption');
+    }
+
+    protected renderTileAction(): React.JSX.Element {
+        return this.renderAqiFace('h5');
+    }
+
+    // --- Dialog ---
+
+    // eslint-disable-next-line class-methods-use-this
+    private renderPollutantRow(row: DisplayRow): React.JSX.Element {
+        return (
+            <Box
+                key={row.key}
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    py: 0.6,
+                    borderBottom: '1px solid',
+                    borderColor: 'divider',
+                }}
+            >
+                <Typography
+                    variant="body2"
+                    sx={{ color: 'text.secondary' }}
+                >
+                    {row.symbol}
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 600, minWidth: 64, textAlign: 'right' }}
+                    >
+                        {row.valueText}
+                    </Typography>
+                    <Box
+                        sx={{
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: '10px',
+                            fontSize: '0.7rem',
+                            fontWeight: 700,
+                            minWidth: 64,
+                            textAlign: 'center',
+                            color: row.levelColor ? '#fff' : 'text.disabled',
+                            backgroundColor: row.levelColor || 'transparent',
+                            border: row.levelColor ? 'none' : '1px solid',
+                            borderColor: row.levelColor ? 'transparent' : 'divider',
+                        }}
+                    >
+                        {row.levelText}
+                    </Box>
+                </Box>
+            </Box>
+        );
+    }
+
+    private renderAmbientRows(): React.JSX.Element | null {
+        const rows: { key: string; label: string; text: string }[] = [];
+        if (this.actualId) {
+            rows.push({
+                key: 'actual',
+                label: I18n.t('wm_Actual temperature'),
+                text: this.formatByUnit(this.state.actual, this.actualUnit),
+            });
+        }
+        if (this.humidityId) {
+            rows.push({
+                key: 'humidity',
+                label: I18n.t('wm_Humidity'),
+                text: this.formatByUnit(this.state.humidity, this.humidityUnit),
+            });
+        }
+        if (this.pressureId) {
+            rows.push({
+                key: 'pressure',
+                label: I18n.t('wm_Pressure'),
+                text: this.formatByUnit(this.state.pressure, this.pressureUnit),
+            });
+        }
+        if (!rows.length) {
+            return null;
+        }
+        return (
+            <Box>
+                {rows.map(row => (
+                    <Box
+                        key={row.key}
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            py: 0.6,
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
+                        }}
+                    >
+                        <Typography
+                            variant="body2"
+                            sx={{ color: 'text.secondary' }}
+                        >
+                            {row.label}
+                        </Typography>
+                        <Typography
+                            variant="body2"
+                            sx={{ fontWeight: 600 }}
+                        >
+                            {row.text}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        );
+    }
+
+    private renderControlDialog(): React.JSX.Element | null {
+        if (!this.state.dialogOpen) {
+            return null;
+        }
+
+        const { name, power } = this.state;
+        const { text: aqiText, color: aqiColor } = this.resolveAqiDisplay();
+        const dimmedSx = this.isPoweredOff() ? { opacity: 0.6, transition: 'opacity 0.25s ease' } : {};
+        const pollutantRows = this.getPollutantRows();
+        const ambientRows = this.renderAmbientRows();
+
+        return (
+            <Dialog
+                open
+                onClose={() => this.setState({ dialogOpen: false })}
+                maxWidth="xs"
+                fullWidth
+                slotProps={{ paper: { sx: { borderRadius: '24px' } } }}
+            >
+                <DialogContent sx={{ p: 3, pt: 2, position: 'relative' }}>
+                    <IconButton
+                        size="small"
+                        onClick={() => this.setState({ dialogOpen: false })}
+                        sx={{ position: 'absolute', top: 8, right: 8 }}
+                    >
+                        <Close fontSize="small" />
+                    </IconButton>
+
+                    <Typography
+                        variant="h6"
+                        sx={{ fontWeight: 600, mb: 2, pr: 4 }}
+                    >
+                        {this.props.settings?.name || name || '...'}
+                    </Typography>
+
+                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 2, ...dimmedSx }}>
+                        <Air sx={{ fontSize: 56, color: aqiColor }} />
+                        <Typography
+                            variant="h5"
+                            sx={{ fontWeight: 700, color: aqiColor, mt: 0.5, textAlign: 'center' }}
+                        >
+                            {aqiText}
+                        </Typography>
+                    </Box>
+
+                    {this.powerId ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
+                            <Button
+                                variant={power ? 'contained' : 'outlined'}
+                                color={power ? 'success' : 'inherit'}
+                                startIcon={<PowerSettingsNew />}
+                                disabled={this.isReadOnly}
+                                onClick={this.togglePower}
+                                size="small"
+                                sx={{ textTransform: 'none', borderRadius: '20px' }}
+                            >
+                                {I18n.t('wm_On/Off')}
+                            </Button>
+                        </Box>
+                    ) : null}
+
+                    {pollutantRows.length ? (
+                        <Box sx={{ mb: ambientRows ? 2 : 0, ...dimmedSx }}>
+                            {pollutantRows.map(row => this.renderPollutantRow(row))}
+                        </Box>
+                    ) : null}
+
+                    {ambientRows ? <Box sx={dimmedSx}>{ambientRows}</Box> : null}
+                </DialogContent>
+            </Dialog>
+        );
+    }
+
+    render(): React.JSX.Element {
+        return (
+            <>
+                {super.render()}
+                {this.renderControlDialog()}
+            </>
+        );
+    }
+}
+
+export default WidgetAirQuality;

--- a/src-admin/src/WidgetsManager/Widgets/airQualityUtils.ts
+++ b/src-admin/src/WidgetsManager/Widgets/airQualityUtils.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure logic for the air-quality widget: worst-first ranking of the eleven pollutants, and the
+ * label-or-number resolution shared by the AQI band and every `*_LEVEL` enum. Kept free of React so
+ * it can be tested directly (see test/airQuality.test.js), the same way commonStates.ts is.
+ */
+
+/** Pattern declaration order, from the installed type-detector's typePatterns.js `airQuality` entry */
+export const POLLUTANT_NAMES = ['CO2', 'TVOC', 'PM1', 'PM25', 'PM10', 'CO', 'NO2', 'O3', 'CH2O', 'RN', 'SO2'] as const;
+export type PollutantName = (typeof POLLUTANT_NAMES)[number];
+
+export interface PollutantRow {
+    name: PollutantName;
+    hasValue: boolean;
+    value: number | null;
+    hasLevel: boolean;
+    /** Normally a number, but see `resolveEnumDisplay` for why a reported string must not be dropped */
+    level: number | string | null;
+}
+
+/** The severities the pattern declares, `0` UNKNOWN through `4` CRITICAL */
+const MAX_LEVEL = 4;
+
+/**
+ * Severity a row sorts by: its LEVEL value when one has arrived, so 0 (UNKNOWN) already sorts below
+ * 1 (LOW) with no special case needed.
+ *
+ * A row with no live severity signal — no LEVEL state, one that hasn't reported, or one reporting
+ * outside the declared 0-4 enum — sinks below every reported level. A value outside that range has no
+ * severity anyone can read: it is shown as the bare number it is, so ranking it above a CRITICAL
+ * reading would put an uninterpretable row at the top of a list that means "worst first".
+ */
+function severityRank(row: PollutantRow): number {
+    if (!row.hasLevel || row.level == null) {
+        return -1;
+    }
+    const numeric = typeof row.level === 'number' ? row.level : Number(row.level);
+    return isNaN(numeric) || numeric < 0 || numeric > MAX_LEVEL ? -1 : numeric;
+}
+
+/**
+ * Worst-first ranking for the dialog's pollutant list. Ties (including the "no severity signal"
+ * bucket) keep the caller's original order, so the list does not reshuffle between renders.
+ */
+export function rankPollutants(rows: readonly PollutantRow[]): PollutantRow[] {
+    return rows
+        .map((row, index) => ({ row, index }))
+        .sort((a, b) => {
+            const bySeverity = severityRank(b.row) - severityRank(a.row);
+            return bySeverity !== 0 ? bySeverity : a.index - b.index;
+        })
+        .map(entry => entry.row);
+}
+
+export interface EnumDisplay {
+    /** A resolved label, or the raw value (with unit, if any) when no label exists */
+    text: string;
+    /** The value's numeric index, only when a label for it was found — used for severity colouring */
+    band: number | null;
+}
+
+/**
+ * The label-or-number rule shared by the AQI band and every LEVEL enum: a datapoint's own
+ * `common.states` wins, the pattern's `defaultStates` is the fallback, and a value with neither is
+ * shown as a plain number — never blank, never "unknown".
+ *
+ * The two sources are chosen as whole maps, never merged key-by-key: a device that labels only some
+ * of its values still means its own scale for the ones it did label, and mixing in the pattern's
+ * labels for the rest would silently splice two unrelated scales into one readout (mirrors
+ * `WidgetFanBase.loadSpeedMeta`, where a datapoint's own list fully replaces the pattern's).
+ *
+ * A datapoint typed `number` may still legitimately report an enum index as a string (the same
+ * reason `WidgetAirCondition`'s MODE reads `string | number`), so a label lookup and the final
+ * fallback both accept either.
+ *
+ * @param value Current reading, `null` while unknown
+ * @param deviceStates Parsed `common.states` of the datapoint itself
+ * @param patternStates Parsed `defaultStates` of the detected pattern
+ * @param unit `common.unit` of the datapoint, `''` when it declares none
+ * @param formatNumber Formats the raw value when it is a number with no label
+ */
+export function resolveEnumDisplay(
+    value: number | string | null,
+    deviceStates: Record<string, string>,
+    patternStates: Record<string, string>,
+    unit: string,
+    formatNumber: (value: number) => string,
+): EnumDisplay {
+    if (value == null) {
+        return { text: '—', band: null };
+    }
+    const states = Object.keys(deviceStates).length ? deviceStates : patternStates;
+    const label = states[String(value)];
+    if (label) {
+        const numeric = typeof value === 'number' ? value : Number(value);
+        return { text: label, band: isNaN(numeric) ? null : numeric };
+    }
+    if (typeof value !== 'number') {
+        return { text: unit ? `${value} ${unit}` : value, band: null };
+    }
+    const num = formatNumber(value);
+    return { text: unit ? `${num} ${unit}` : num, band: null };
+}
+
+/**
+ * Maps a resolved label to one of this widget's own translation keys.
+ *
+ * The pattern's `defaultStates` use fixed English names (`GOOD`, `CRITICAL`, ...); a datapoint's own
+ * `common.states` may say the same thing, in any casing or spacing, or something else entirely —
+ * either way, only a recognised name gets translated, everything else is shown as the device wrote
+ * it (mirrors `WidgetFanBase.getSpeedLabel`).
+ */
+export function knownLabelKey(label: string, map: Record<string, string>): string | null {
+    return (
+        map[
+            label
+                .trim()
+                .toUpperCase()
+                .replace(/[\s-]+/g, '_')
+        ] ?? null
+    );
+}

--- a/src-admin/src/WidgetsManager/Widgets/index.ts
+++ b/src-admin/src/WidgetsManager/Widgets/index.ts
@@ -1,6 +1,7 @@
 export { WidgetPlugin } from './WidgetPlugin';
 export { WidgetAirCondition } from './AirCondition';
 export { WidgetAirPurifier } from './AirPurifier';
+export { WidgetAirQuality } from './AirQuality';
 export { WidgetBlind } from './Blind';
 export { WidgetBlindButtons } from './BlindButtons';
 export { WidgetButton } from './Button';

--- a/src-admin/src/WidgetsManager/i18n/de.json
+++ b/src-admin/src/WidgetsManager/i18n/de.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pumpe",
     "wm_Level": "Stufe",
     "wm_Temperature": "Temperatur",
-    "wm_Flow": "Durchfluss"
+    "wm_Flow": "Durchfluss",
+    "wm_Air quality": "Luftqualität",
+    "wm_aqi_unknown": "Unbekannt",
+    "wm_aqi_good": "Gut",
+    "wm_aqi_fair": "Mäßig",
+    "wm_aqi_moderate": "Mittelmäßig",
+    "wm_aqi_poor": "Schlecht",
+    "wm_aqi_very_poor": "Sehr schlecht",
+    "wm_aqi_extremely_poor": "Extrem schlecht",
+    "wm_level_unknown": "Unbekannt",
+    "wm_level_low": "Niedrig",
+    "wm_level_medium": "Mittel",
+    "wm_level_high": "Hoch",
+    "wm_level_critical": "Kritisch"
 }

--- a/src-admin/src/WidgetsManager/i18n/en.json
+++ b/src-admin/src/WidgetsManager/i18n/en.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pump",
     "wm_Level": "Level",
     "wm_Temperature": "Temperature",
-    "wm_Flow": "Flow"
+    "wm_Flow": "Flow",
+    "wm_Air quality": "Air quality",
+    "wm_aqi_unknown": "Unknown",
+    "wm_aqi_good": "Good",
+    "wm_aqi_fair": "Fair",
+    "wm_aqi_moderate": "Moderate",
+    "wm_aqi_poor": "Poor",
+    "wm_aqi_very_poor": "Very poor",
+    "wm_aqi_extremely_poor": "Extremely poor",
+    "wm_level_unknown": "Unknown",
+    "wm_level_low": "Low",
+    "wm_level_medium": "Medium",
+    "wm_level_high": "High",
+    "wm_level_critical": "Critical"
 }

--- a/src-admin/src/WidgetsManager/i18n/es.json
+++ b/src-admin/src/WidgetsManager/i18n/es.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Bomba",
     "wm_Level": "Nivel",
     "wm_Temperature": "Temperatura",
-    "wm_Flow": "Caudal"
+    "wm_Flow": "Caudal",
+    "wm_Air quality": "Calidad del aire",
+    "wm_aqi_unknown": "Desconocido",
+    "wm_aqi_good": "Buena",
+    "wm_aqi_fair": "Aceptable",
+    "wm_aqi_moderate": "Moderada",
+    "wm_aqi_poor": "Mala",
+    "wm_aqi_very_poor": "Muy mala",
+    "wm_aqi_extremely_poor": "Extremadamente mala",
+    "wm_level_unknown": "Desconocido",
+    "wm_level_low": "Bajo",
+    "wm_level_medium": "Medio",
+    "wm_level_high": "Alto",
+    "wm_level_critical": "Crítico"
 }

--- a/src-admin/src/WidgetsManager/i18n/fr.json
+++ b/src-admin/src/WidgetsManager/i18n/fr.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pompe",
     "wm_Level": "Niveau",
     "wm_Temperature": "Température",
-    "wm_Flow": "Débit"
+    "wm_Flow": "Débit",
+    "wm_Air quality": "Qualité de l'air",
+    "wm_aqi_unknown": "Inconnu",
+    "wm_aqi_good": "Bonne",
+    "wm_aqi_fair": "Moyenne",
+    "wm_aqi_moderate": "Modérée",
+    "wm_aqi_poor": "Mauvaise",
+    "wm_aqi_very_poor": "Très mauvaise",
+    "wm_aqi_extremely_poor": "Extrêmement mauvaise",
+    "wm_level_unknown": "Inconnu",
+    "wm_level_low": "Faible",
+    "wm_level_medium": "Moyen",
+    "wm_level_high": "Élevé",
+    "wm_level_critical": "Critique"
 }

--- a/src-admin/src/WidgetsManager/i18n/it.json
+++ b/src-admin/src/WidgetsManager/i18n/it.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pompa",
     "wm_Level": "Livello",
     "wm_Temperature": "Temperatura",
-    "wm_Flow": "Portata"
+    "wm_Flow": "Portata",
+    "wm_Air quality": "Qualità dell'aria",
+    "wm_aqi_unknown": "Sconosciuto",
+    "wm_aqi_good": "Buona",
+    "wm_aqi_fair": "Discreta",
+    "wm_aqi_moderate": "Moderata",
+    "wm_aqi_poor": "Scarsa",
+    "wm_aqi_very_poor": "Molto scarsa",
+    "wm_aqi_extremely_poor": "Estremamente scarsa",
+    "wm_level_unknown": "Sconosciuto",
+    "wm_level_low": "Basso",
+    "wm_level_medium": "Medio",
+    "wm_level_high": "Alto",
+    "wm_level_critical": "Critico"
 }

--- a/src-admin/src/WidgetsManager/i18n/nl.json
+++ b/src-admin/src/WidgetsManager/i18n/nl.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pomp",
     "wm_Level": "Niveau",
     "wm_Temperature": "Temperatuur",
-    "wm_Flow": "Doorstroming"
+    "wm_Flow": "Doorstroming",
+    "wm_Air quality": "Luchtkwaliteit",
+    "wm_aqi_unknown": "Onbekend",
+    "wm_aqi_good": "Goed",
+    "wm_aqi_fair": "Redelijk",
+    "wm_aqi_moderate": "Matig",
+    "wm_aqi_poor": "Slecht",
+    "wm_aqi_very_poor": "Zeer slecht",
+    "wm_aqi_extremely_poor": "Extreem slecht",
+    "wm_level_unknown": "Onbekend",
+    "wm_level_low": "Laag",
+    "wm_level_medium": "Gemiddeld",
+    "wm_level_high": "Hoog",
+    "wm_level_critical": "Kritiek"
 }

--- a/src-admin/src/WidgetsManager/i18n/pl.json
+++ b/src-admin/src/WidgetsManager/i18n/pl.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Pompa",
     "wm_Level": "Poziom",
     "wm_Temperature": "Temperatura",
-    "wm_Flow": "Przepływ"
+    "wm_Flow": "Przepływ",
+    "wm_Air quality": "Jakość powietrza",
+    "wm_aqi_unknown": "Nieznany",
+    "wm_aqi_good": "Dobra",
+    "wm_aqi_fair": "Umiarkowana",
+    "wm_aqi_moderate": "Średnia",
+    "wm_aqi_poor": "Zła",
+    "wm_aqi_very_poor": "Bardzo zła",
+    "wm_aqi_extremely_poor": "Skrajnie zła",
+    "wm_level_unknown": "Nieznany",
+    "wm_level_low": "Niski",
+    "wm_level_medium": "Średni",
+    "wm_level_high": "Wysoki",
+    "wm_level_critical": "Krytyczny"
 }

--- a/src-admin/src/WidgetsManager/i18n/pt.json
+++ b/src-admin/src/WidgetsManager/i18n/pt.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Bomba",
     "wm_Level": "Nível",
     "wm_Temperature": "Temperatura",
-    "wm_Flow": "Vazão"
+    "wm_Flow": "Vazão",
+    "wm_Air quality": "Qualidade do ar",
+    "wm_aqi_unknown": "Desconhecido",
+    "wm_aqi_good": "Boa",
+    "wm_aqi_fair": "Razoável",
+    "wm_aqi_moderate": "Moderada",
+    "wm_aqi_poor": "Fraca",
+    "wm_aqi_very_poor": "Muito fraca",
+    "wm_aqi_extremely_poor": "Extremamente fraca",
+    "wm_level_unknown": "Desconhecido",
+    "wm_level_low": "Baixo",
+    "wm_level_medium": "Médio",
+    "wm_level_high": "Alto",
+    "wm_level_critical": "Crítico"
 }

--- a/src-admin/src/WidgetsManager/i18n/ru.json
+++ b/src-admin/src/WidgetsManager/i18n/ru.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Насос",
     "wm_Level": "Уровень",
     "wm_Temperature": "Температура",
-    "wm_Flow": "Расход"
+    "wm_Flow": "Расход",
+    "wm_Air quality": "Качество воздуха",
+    "wm_aqi_unknown": "Неизвестно",
+    "wm_aqi_good": "Хорошее",
+    "wm_aqi_fair": "Приемлемое",
+    "wm_aqi_moderate": "Среднее",
+    "wm_aqi_poor": "Плохое",
+    "wm_aqi_very_poor": "Очень плохое",
+    "wm_aqi_extremely_poor": "Крайне плохое",
+    "wm_level_unknown": "Неизвестно",
+    "wm_level_low": "Низкий",
+    "wm_level_medium": "Средний",
+    "wm_level_high": "Высокий",
+    "wm_level_critical": "Критический"
 }

--- a/src-admin/src/WidgetsManager/i18n/uk.json
+++ b/src-admin/src/WidgetsManager/i18n/uk.json
@@ -580,5 +580,18 @@
     "wm_Pump": "Насос",
     "wm_Level": "Рівень",
     "wm_Temperature": "Температура",
-    "wm_Flow": "Витрата"
+    "wm_Flow": "Витрата",
+    "wm_Air quality": "Якість повітря",
+    "wm_aqi_unknown": "Невідомо",
+    "wm_aqi_good": "Добра",
+    "wm_aqi_fair": "Прийнятна",
+    "wm_aqi_moderate": "Помірна",
+    "wm_aqi_poor": "Погана",
+    "wm_aqi_very_poor": "Дуже погана",
+    "wm_aqi_extremely_poor": "Надзвичайно погана",
+    "wm_level_unknown": "Невідомо",
+    "wm_level_low": "Низький",
+    "wm_level_medium": "Середній",
+    "wm_level_high": "Високий",
+    "wm_level_critical": "Критичний"
 }

--- a/src-admin/src/WidgetsManager/i18n/zh-cn.json
+++ b/src-admin/src/WidgetsManager/i18n/zh-cn.json
@@ -580,5 +580,18 @@
     "wm_Pump": "水泵",
     "wm_Level": "档位",
     "wm_Temperature": "温度",
-    "wm_Flow": "流量"
+    "wm_Flow": "流量",
+    "wm_Air quality": "空气质量",
+    "wm_aqi_unknown": "未知",
+    "wm_aqi_good": "优",
+    "wm_aqi_fair": "良",
+    "wm_aqi_moderate": "中等",
+    "wm_aqi_poor": "差",
+    "wm_aqi_very_poor": "很差",
+    "wm_aqi_extremely_poor": "极差",
+    "wm_level_unknown": "未知",
+    "wm_level_low": "低",
+    "wm_level_medium": "中",
+    "wm_level_high": "高",
+    "wm_level_critical": "严重"
 }

--- a/test/airQuality.test.js
+++ b/test/airQuality.test.js
@@ -1,0 +1,194 @@
+const { expect } = require('chai');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { Module } = require('node:module');
+const ts = require('typescript');
+
+/**
+ * `src-admin/src/WidgetsManager/Widgets/airQualityUtils.ts` is pure logic, so it can be transpiled
+ * and loaded here without pulling in React or the bundler (mirrors test/commonStates.test.js).
+ */
+function loadAirQualityUtils() {
+    const file = join(__dirname, '..', 'src-admin', 'src', 'WidgetsManager', 'Widgets', 'airQualityUtils.ts');
+    const { outputText } = ts.transpileModule(readFileSync(file, 'utf8'), {
+        compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+        fileName: file,
+    });
+    const mod = new Module(file);
+    mod.filename = file;
+    mod._compile(outputText, file);
+    return mod.exports;
+}
+
+const { rankPollutants, resolveEnumDisplay, knownLabelKey } = loadAirQualityUtils();
+
+function row(name, overrides) {
+    return { name, hasValue: false, value: null, hasLevel: false, level: null, ...overrides };
+}
+
+describe('WidgetsManager airQualityUtils', () => {
+    describe('rankPollutants', () => {
+        it('sorts by LEVEL worst-first', () => {
+            const rows = [
+                row('CO2', { hasLevel: true, level: 1 }),
+                row('TVOC', { hasLevel: true, level: 4 }),
+                row('PM1', { hasLevel: true, level: 2 }),
+            ];
+            expect(rankPollutants(rows).map(r => r.name)).to.deep.equal(['TVOC', 'PM1', 'CO2']);
+        });
+
+        it('sorts reported UNKNOWN (0) below every reported level, not as if it were good', () => {
+            const rows = [row('CO2', { hasLevel: true, level: 0 }), row('TVOC', { hasLevel: true, level: 1 })];
+            expect(rankPollutants(rows).map(r => r.name)).to.deep.equal(['TVOC', 'CO2']);
+        });
+
+        it('sinks a row with no LEVEL state below every row that has one, keeping pattern order', () => {
+            const rows = [
+                row('CO2', { hasValue: true, value: 800 }), // value only, no LEVEL pattern match
+                row('TVOC', { hasLevel: true, level: 0 }), // reported UNKNOWN
+                row('PM1', { hasLevel: true, level: 1 }),
+            ];
+            expect(rankPollutants(rows).map(r => r.name)).to.deep.equal(['PM1', 'TVOC', 'CO2']);
+        });
+
+        it('sinks a LEVEL that has not reported yet (null) together with "no LEVEL at all", tied by pattern order', () => {
+            const rows = [
+                row('CO2', { hasLevel: true, level: null }), // declared, not arrived yet
+                row('TVOC', { hasValue: true, value: 400 }), // no LEVEL pattern match at all
+                row('PM1', { hasLevel: true, level: 3 }),
+            ];
+            const ranked = rankPollutants(rows).map(r => r.name);
+            expect(ranked[0]).to.equal('PM1');
+            // CO2 was declared before TVOC in the input, and both tie at "no severity signal"
+            expect(ranked.slice(1)).to.deep.equal(['CO2', 'TVOC']);
+        });
+
+        it('ranks a LEVEL reported as a string the same as the equivalent number', () => {
+            const rows = [
+                row('CO2', { hasLevel: true, level: '2' }),
+                row('TVOC', { hasLevel: true, level: 4 }),
+                row('PM1', { hasLevel: true, level: '1' }),
+            ];
+            expect(rankPollutants(rows).map(r => r.name)).to.deep.equal(['TVOC', 'CO2', 'PM1']);
+        });
+
+        it('sinks a LEVEL outside the declared 0-4 enum below every readable severity', () => {
+            // Such a value renders as a bare uncoloured number, so ranking it first would put the one
+            // row nobody can interpret at the top of a list that means "worst first"
+            const ranked = rankPollutants([
+                row('CO2', { hasLevel: true, level: 7 }),
+                row('PM25', { hasLevel: true, level: 4 }),
+                row('CO', { hasLevel: true, level: 1 }),
+            ]);
+            expect(ranked.map(r => r.name)).to.deep.equal(['PM25', 'CO', 'CO2']);
+        });
+
+        it('sinks a negative LEVEL the same way', () => {
+            const ranked = rankPollutants([
+                row('CO2', { hasLevel: true, level: -1 }),
+                row('PM25', { hasLevel: true, level: 0 }),
+            ]);
+            expect(ranked.map(r => r.name)).to.deep.equal(['PM25', 'CO2']);
+        });
+
+        it('keeps CRITICAL at the top when another row reports garbage', () => {
+            const ranked = rankPollutants([
+                row('CO2', { hasLevel: true, level: 99 }),
+                row('PM25', { hasLevel: true, level: 4 }),
+            ]);
+            expect(ranked[0].name).to.equal('PM25');
+        });
+
+        it('does not mutate the input array', () => {
+            const rows = [row('CO2', { hasLevel: true, level: 1 }), row('TVOC', { hasLevel: true, level: 4 })];
+            const copy = rows.map(r => ({ ...r }));
+            rankPollutants(rows);
+            expect(rows).to.deep.equal(copy);
+        });
+    });
+
+    describe('resolveEnumDisplay', () => {
+        const patternStates = { 0: 'UNKNOWN', 1: 'GOOD', 2: 'FAIR' };
+        /** Stands in for the widget's real formatter, which only ever receives a number */
+        const numberOnly = value => {
+            if (typeof value !== 'number') {
+                throw new TypeError(`numeric formatter received a ${typeof value}`);
+            }
+            return String(value);
+        };
+
+        it('renders a dash for a value that has not arrived yet', () => {
+            expect(resolveEnumDisplay(null, {}, patternStates, '', String)).to.deep.equal({ text: '—', band: null });
+        });
+
+        it("prefers the datapoint's own common.states over the pattern default", () => {
+            const result = resolveEnumDisplay(1, { 1: 'Custom Good' }, patternStates, '', String);
+            expect(result).to.deep.equal({ text: 'Custom Good', band: 1 });
+        });
+
+        it('falls back to the pattern default when the datapoint declares no label for the value', () => {
+            const result = resolveEnumDisplay(2, {}, patternStates, '', String);
+            expect(result).to.deep.equal({ text: 'FAIR', band: 2 });
+        });
+
+        it("does not splice in the pattern label for a value the datapoint's own list left unlabelled", () => {
+            // The device labelled 0 and 1 only; 2 is not a gap to fill from the pattern's FAIR — the
+            // device's own list, once non-empty, is the whole story, or a 0-500 index sitting at 2
+            // would be shown as "FAIR" purely by coincidence of the pattern's numbering.
+            const result = resolveEnumDisplay(2, { 0: 'Clean', 1: 'Dirty' }, patternStates, '', String);
+            expect(result).to.deep.equal({ text: '2', band: null });
+        });
+
+        it('shows the raw number, never "unknown", when neither source has a label (e.g. a 0-500 EPA-style AQI)', () => {
+            const result = resolveEnumDisplay(137, {}, patternStates, '', String);
+            expect(result).to.deep.equal({ text: '137', band: null });
+        });
+
+        it('appends the unit for the unlabelled numeric fallback', () => {
+            const result = resolveEnumDisplay(137, {}, {}, 'AQI', String);
+            expect(result).to.deep.equal({ text: '137 AQI', band: null });
+        });
+
+        it('does not append the unit when a label was found', () => {
+            const result = resolveEnumDisplay(1, {}, patternStates, 'AQI', String);
+            expect(result).to.deep.equal({ text: 'GOOD', band: 1 });
+        });
+
+        it('falls through to the number rather than showing a declared-but-empty label', () => {
+            const result = resolveEnumDisplay(1, { 1: '' }, {}, '', String);
+            expect(result).to.deep.equal({ text: '1', band: null });
+        });
+
+        it('accepts a value reported as a string, resolving the label and the band the same as a number', () => {
+            const result = resolveEnumDisplay('1', {}, patternStates, '', String);
+            expect(result).to.deep.equal({ text: 'GOOD', band: 1 });
+        });
+
+        it('shows an unlabelled string value as-is instead of handing it to the numeric formatter', () => {
+            const result = resolveEnumDisplay('GOOD', {}, {}, '', numberOnly);
+            expect(result).to.deep.equal({ text: 'GOOD', band: null });
+        });
+
+        it('appends the unit to an unlabelled string value too', () => {
+            const result = resolveEnumDisplay('HAZE', {}, {}, 'ppm', numberOnly);
+            expect(result).to.deep.equal({ text: 'HAZE ppm', band: null });
+        });
+    });
+
+    describe('knownLabelKey', () => {
+        const map = { GOOD: 'wm_aqi_good', VERY_POOR: 'wm_aqi_very_poor' };
+
+        it('matches regardless of case', () => {
+            expect(knownLabelKey('good', map)).to.equal('wm_aqi_good');
+        });
+
+        it('matches a space- or hyphen-separated label against an underscore-separated key', () => {
+            expect(knownLabelKey('Very Poor', map)).to.equal('wm_aqi_very_poor');
+            expect(knownLabelKey('very-poor', map)).to.equal('wm_aqi_very_poor');
+        });
+
+        it('returns null for a label the map does not recognise, leaving it to be shown as-is', () => {
+            expect(knownLabelKey('Sehr gut', map)).to.equal(null);
+        });
+    });
+});


### PR DESCRIPTION
The last of the nine device types type-detector 6.0.0 added, and the only one that was ever an
information-design problem rather than plumbing. One commit, source only, rebased onto master after
#669.

`airQuality` has been rendering the generic info tile since the bump — one value, labelled with
whatever the datapoint is named. That was a deliberate stopgap for a type with **34 states**.

## AQI is a band, not a number

The pattern declares it as a seven-value enum, so the tile face shows the word and colours it — "3"
tells a user nothing where "MODERATE" tells them everything:

    AQI  {0:UNKNOWN, 1:GOOD, 2:FAIR, 3:MODERATE, 4:POOR, 5:VERY_POOR, 6:EXTREMELY_POOR}

**But nothing obliges a device to use that enum.** Adapters report a US-EPA-style 0–500 AQI as a plain
number. So the label resolves in order — the datapoint's own `common.states`, then the pattern's
`defaultStates` — and a value with a label in neither is shown as *the number it is*. A device
reporting 137 reads "137", never "unknown" and never blank.

**Colour is claimed on narrower evidence than the label.** A device may use the same 0–6 indices for a
scale of its own, so a band only tints when the resolved label is one of the seven this scale means.
The eleven pollutant `*_LEVEL` states do trust their 0–4 index, because that numeric domain is the one
thing the detector guarantees for them where it does not for AQI. The asymmetry is deliberate.

## The dialog is what makes eleven concentrations readable

Rows sort by severity, **worst first**, so the pollutant that matters is at the top rather than wherever
the pattern happens to declare it. Every `*_LEVEL` shares one scale:

    {0:UNKNOWN, 1:LOW, 2:MEDIUM, 3:HIGH, 4:CRITICAL}

A row with nothing to rank by — no level state, none reported yet, or one **outside** the declared enum
— sinks below every readable severity. That last case was a real defect the review caught: a level
reporting `7` outranked a genuine CRITICAL while rendering as a bare uncoloured "7", putting the one row
nobody can interpret at the top of a list that means "worst first". Three tests pin it now.

Pollutants the device does not have get no row. Ambient temperature, humidity and pressure form their
own unranked section, since they carry no severity.

## Nothing is presented as better than the evidence supports

For an air-quality monitor this is the failure that matters, so each of these is deliberate:

- A reading that has not arrived is a dash, never a zero.
- `UNKNOWN` is grey, never green — "we don't know" must not read as "fine".
- A reading from a device that is **switched off is dimmed on the tile face as well as in the dialog**.
  It is the last measurement it took, not the air now. The face previously kept a fully saturated green
  "Good" indefinitely while the dialog dimmed the identical value — also a review finding.
- Units come from the datapoint throughout. Four of the eleven pollutants declare no unit at all, so a
  widget that assumed one would print something the device never said.

The dialog opens for a read-only widget, as `Pump` and `FanBase` now do: it is where the readings live,
and someone who may not switch the device off may still read them. `POWER` is the only writable state
and the only `setValue()` call in the file.

## Tested where it is testable

The ranking and the label-or-number rule are extracted into `airQualityUtils.ts`, free of React, and
covered by **23 unit tests** — pure logic tested directly rather than through a rendered tree. `test:unit`
is 100 tests total.

Every test was mutation-checked rather than counted. That found one passing for the wrong reason: the
case named *"shows an unlabelled string value as-is instead of crashing the numeric formatter"* passed
`String` as the formatter, which accepts a string happily, so deleting the guard it exists to protect
left the suite green. The fake now throws on a non-number, and the mutation fails with exactly that
`TypeError`.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, full `npm run build`,
`test:unit` (100) and `test:package` (47). i18n at 595 keys with identical sets across all 11 files.

Rebased onto master after #669; the only conflict was both branches appending i18n keys, resolved by
keeping both sides — `wm_Pump`/`wm_Level`/`wm_Temperature`/`wm_Flow` from #669 and the 13 new ones here
all present, verified by key-set comparison rather than by eye.

An independent adversarial review covered eight areas. Two findings are fixed here (the out-of-range
severity and the undimmed face); a third — `*_LEVEL` fallback labels hardcoded where AQI's were read
from the pattern — is fixed too, no live bug but an inconsistency that would have drifted. Two are
deliberately not: there are no tests for the React component itself (the pure logic is what is
testable), and the unmounted-`setState`-after-`await` shape is identical in `Generic.tsx`, `FanBase.tsx`
and `Electricity.tsx` — systemic, not introduced here, and not something to fix in one widget.

## This completes the upgrade

```
contact  coAlarm  pressure  flow      #665
fan      airPurifier                  #667
electricity                           #668
pump                                  #669
airQuality                            this PR
```

All nine types type-detector 6.0.0 split out now have purpose-built tiles, and **the info-tile stopgap
the bump shipped with is gone** — `WidgetInfo` serves only `Types.info` again.

## Follow-ups

- `WidgetAirCondition` could adopt `FanBase`, and `Illuminance`/`Humidity`/`Temperature` could adopt
  `SingleValueSensorBase`. Both are retro-fits of shipping widgets, each its own change.
- "POWER toggle + percentage slider" now exists in `Dimmer`, `FanBase` and `Pump` — a shared base is
  worth considering.
- `Category.tsx`'s private `normalizeWatts`/`formatPower` are still the only copy of that logic; whether
  the "i" dialog should auto-scale `W`/`Wh` for every widget carrying them is an open question.
- **[adapter-react-v5#123](https://github.com/ioBroker/adapter-react-v5/issues/123)** — gui-components
  still has no icon and no `type-*` name for any of the nine, so they render a bare first letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
