### PR TITLE
fix(widgets): let a climate tile open its dialog at every size

### DIFF
--- a/src-admin/src/WidgetsManager/Widgets/AirCondition.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/AirCondition.tsx
@@ -1908,8 +1908,6 @@ export class WidgetAirCondition extends WidgetGeneric<WidgetAirConditionState> {
                     </Box>
                     {this.renderChart()}
                 </ButtonBase>
-
-                {this.renderDialog()}
             </Box>
         );
     }
@@ -2041,9 +2039,21 @@ export class WidgetAirCondition extends WidgetGeneric<WidgetAirConditionState> {
                     </Box>
                     {this.renderChart()}
                 </ButtonBase>
-
-                {this.renderDialog()}
             </Box>
+        );
+    }
+
+    /**
+     * Rendered beside the tile rather than inside a layout: the 2x0.5 layout comes from the base
+     * class, so a dialog rendered only by the layouts this widget overrides could not open at that
+     * size at all.
+     */
+    render(): React.JSX.Element {
+        return (
+            <>
+                {super.render()}
+                {this.renderDialog()}
+            </>
         );
     }
 }

--- a/src-admin/src/WidgetsManager/Widgets/Motion.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Motion.tsx
@@ -5,10 +5,6 @@ import { I18n, Icon } from '@iobroker/gui-components';
 
 import WidgetGeneric, { type WidgetGenericSettings, type WidgetGenericProps, type WidgetGenericState } from './Generic';
 
-interface AlarmWidgetSettings extends WidgetGenericSettings {
-    hideWhenOk?: boolean;
-}
-
 interface WidgetMotionState extends WidgetGenericState {
     motion: boolean;
     brightness: number | null;
@@ -19,12 +15,12 @@ interface WidgetMotionState extends WidgetGenericState {
     lastMotionAgo: string;
 }
 
-export class WidgetMotion extends WidgetGeneric<WidgetMotionState, AlarmWidgetSettings> {
+export class WidgetMotion extends WidgetGeneric<WidgetMotionState, WidgetGenericSettings> {
     private readonly actualId: string | null;
     private readonly brightnessId: string | null;
     private agoTimer: ReturnType<typeof setInterval> | null = null;
 
-    constructor(props: WidgetGenericProps<AlarmWidgetSettings>) {
+    constructor(props: WidgetGenericProps<WidgetGenericSettings>) {
         super(props);
         const states = props.widget.control.states;
         const actual = states.find(s => s.name === 'ACTUAL');

--- a/src-admin/src/WidgetsManager/Widgets/Thermostat.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Thermostat.tsx
@@ -1573,8 +1573,6 @@ export class WidgetThermostat extends WidgetGeneric<WidgetThermostatState> {
                     </Box>
                     {this.renderChart()}
                 </ButtonBase>
-
-                {this.renderDialog()}
             </Box>
         );
     }
@@ -1696,9 +1694,21 @@ export class WidgetThermostat extends WidgetGeneric<WidgetThermostatState> {
 
                     {this.renderChart()}
                 </ButtonBase>
-
-                {this.renderDialog()}
             </Box>
+        );
+    }
+
+    /**
+     * Rendered beside the tile rather than inside a layout: the 2x0.5 layout comes from the base
+     * class, so a dialog rendered only by the layouts this widget overrides could not open at that
+     * size at all.
+     */
+    render(): React.JSX.Element {
+        return (
+            <>
+                {super.render()}
+                {this.renderDialog()}
+            </>
         );
     }
 }

--- a/src-admin/src/WidgetsManager/Widgets/Window.tsx
+++ b/src-admin/src/WidgetsManager/Widgets/Window.tsx
@@ -5,10 +5,6 @@ import { I18n, Icon } from '@iobroker/gui-components';
 
 import WidgetGeneric, { type WidgetGenericSettings, type WidgetGenericProps, type WidgetGenericState } from './Generic';
 
-interface AlarmWidgetSettings extends WidgetGenericSettings {
-    hideWhenOk?: boolean;
-}
-
 /** Official value.window: 0 = CLOSED, 1 = TILTED, 2 = OPEN */
 // acording to: https://www.iobroker.net/#en/documentation/dev/stateroles.md?info
 type WindowOpenState = 0 | 1 | 2;
@@ -22,11 +18,11 @@ interface WidgetWindowState extends WidgetGenericState {
     lastChangedAgo: string;
 }
 
-export class WidgetWindow extends WidgetGeneric<WidgetWindowState, AlarmWidgetSettings> {
+export class WidgetWindow extends WidgetGeneric<WidgetWindowState, WidgetGenericSettings> {
     private readonly actualId: string | null;
     private agoTimer: ReturnType<typeof setInterval> | null = null;
 
-    constructor(props: WidgetGenericProps<AlarmWidgetSettings>) {
+    constructor(props: WidgetGenericProps<WidgetGenericSettings>) {
         super(props);
         const states = props.widget.control.states;
         const actual = states.find(s => s.name === 'ACTUAL');


### PR DESCRIPTION
Two loose ends found while finishing the type-detector 6.0.0 work. Both are in shipping widgets and
neither is caused by that work.

## A climate tile at 2x0.5 could not open its dialog

`Thermostat` and `AirCondition` render their dialog inside `renderCompact` and `renderWideTall`. The
2x0.5 layout comes from `WidgetGeneric.renderWide()`, which neither widget overrides — so at that size
the dialog was never rendered. Clicking the tile did nothing, and everything on the dialog was
unreachable: both setpoints, the mode list, the fan speed, the swing, the airflow direction.

Both now render it beside the tile in a `render()` override:

```tsx
render(): React.JSX.Element {
    return (
        <>
            {super.render()}
            {this.renderDialog()}
        </>
    );
}
```

That is what `FanBase`, `Pump` and `AirQuality` already do, and it is the reason those three were never
affected — the dialog stops depending on which layouts a widget happens to override. Verified per
widget: the dialog is now rendered once, from `render()`, and no longer from either layout.

Scoped by checking every widget with a dialog, not by assumption:

| widget | dialog in `render()` | affected |
| --- | --- | --- |
| `Thermostat` | now yes | was broken at 2x0.5 |
| `AirCondition` | now yes | was broken at 2x0.5 |
| `FanBase` (fan, airPurifier) | yes | never affected |
| `Pump` | yes | never affected |
| `AirQuality` | yes | never affected |

## A settings field two widgets promised and ignored

`Motion` and `Window` each declared `hideWhenOk?: boolean` on a local `AlarmWidgetSettings`. Neither
exposes it in its config schema and neither reads it, so it was a type promising behaviour the widget
does not have. `FireAlarm`, `FloodAlarm` and `Warning` implement it properly and keep theirs.

Removing the field left that interface with no members of its own in both widgets — it existed only to
carry the field — so both now use `WidgetGenericSettings` directly. `eslint` caught that, not I.

`Window` is the base of `Door` and `Contact`; none of the three read the field, so nothing changes for
them at runtime.

## Verification

`tsc --noEmit` (src-admin and the backend project), `eslint`, `prettier --check`, `test:unit` (77).

## Not fixed here: `npm ci` is still blocked

The last open item from this work is that `check-and-lint` installs with `npm run npm && npm run build`
rather than `npm ci`, which costs lock-sync verification. It cannot simply be switched: `npm ci
--dry-run` fails in two of the four install roots on the same two transitive packages. Filed separately
rather than fixed here, since it needs lockfiles regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
