### PR TITLE
Stop deleting an edited added state when its name did not change

### DIFF
--- a/src-admin/src/Dialogs/DialogEditDevice.tsx
+++ b/src-admin/src/Dialogs/DialogEditDevice.tsx
@@ -577,19 +577,28 @@ class DialogEditDevice extends React.Component<DialogEditDeviceProps, DialogEdit
                             this.setState({ dialogAddState: null });
                             return;
                         }
+                        // The dialog writes `common.name` as a plain string; only a foreign/older
+                        // object could still carry a translation record here.
                         const objName = obj?.common?.name;
-                        let oldName: string;
+                        let newName: string;
                         if (typeof objName === 'object') {
-                            oldName =
+                            newName =
                                 objName[I18n.getLanguage()] ||
                                 objName.en ||
                                 objName[Object.keys(objName)[0] as ioBroker.Languages] ||
                                 '';
                         } else {
-                            oldName = '';
+                            newName = objName || '';
                         }
 
-                        if (this.state.dialogAddState!.onClose && oldName !== this.state.dialogAddState!.name) {
+                        // Delete the old object only on a real rename: with an unchanged name the
+                        // dialog has overwritten the object in place, so `item.id` IS the object
+                        // that was just saved.
+                        if (
+                            this.state.dialogAddState!.onClose &&
+                            newName &&
+                            newName !== this.state.dialogAddState!.name
+                        ) {
                             await this.onDelete(this.state.dialogAddState!.item!.id);
                             const newIds: Record<
                                 string,
@@ -600,9 +609,14 @@ class DialogEditDevice extends React.Component<DialogEditDeviceProps, DialogEdit
                                   }
                             > = JSON.parse(JSON.stringify(this.state.ids));
 
+                            // Carry the unsaved in-session mapping over to the state's new name —
+                            // keyed by the old name it would no longer reach the state, keyed by ''
+                            // it would leak into `ids` as a ghost entry.
                             const newValue = newIds[this.state.dialogAddState!.name!];
                             delete newIds[this.state.dialogAddState!.name!];
-                            newIds[oldName] = newValue;
+                            if (newValue !== undefined) {
+                                newIds[newName] = newValue;
+                            }
                             this.setState({ ids: newIds, dialogAddState: null });
                         } else {
                             this.setState({ dialogAddState: null });


### PR DESCRIPTION
## What the user sees

Open the pencil ("Edit state") next to an *added* state, change e.g. min/max or the role, keep the name, save — and the state is gone. The dialog saved the object in place, and the close handler then deleted "the old id", which with an unchanged name is exactly the object that was just saved.

## Cause

`renderDialogAddState` in `DialogEditDevice.tsx` derives the "was it renamed?" answer from the freshly saved object's `common.name`. That name is always a plain string here, but the string branch discarded it and compared `''` against the old name, so **every** edit counted as a rename and triggered the delete. On a real rename the same mix-up filed the in-session alias mapping under the key `''` instead of the new name, losing the assignment. The logic traces back to the TypeScript migration.

## Fix

- derive the new name from the string form as well,
- delete the old object only when the name really changed,
- carry the unsaved in-session mapping over to the state's new name.

May be related to what #360 describes (datapoints disappearing while editing a device).

## Verification

`tsc --noEmit`, `eslint` and a full `vite build` of `src-admin` are green. The failure path is code-traced (dialog always returns a string name → `oldName` was always `''`); not exercised against a live GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)