### PR TITLE
Return the derived state instead of mutating it in TreeView.getDerivedStateFromProps

### DIFF
--- a/src-admin/src/Components/TreeView.tsx
+++ b/src-admin/src/Components/TreeView.tsx
@@ -333,17 +333,19 @@ export default class TreeView extends React.Component<TreeViewProps, TreeViewSta
     }
 
     static getDerivedStateFromProps(props: TreeViewProps, state: TreeViewState): Partial<TreeViewState> | null {
-        let changed = false;
-        const newState: Partial<TreeViewState> = {};
         if (props.objects) {
-            const listItems = prepareList(props.objects || {});
+            // The deep compare is required: the caller mutates its `objects` record in place, so
+            // the reference never changes and only the content can tell whether the list moved.
+            const listItems = prepareList(props.objects);
             if (JSON.stringify(listItems) !== JSON.stringify(state.listItems)) {
-                state.listItems = listItems;
-                changed = true;
+                // Returned, not written into `state` — React applies the partial itself; mutating
+                // the passed state object works only by accident and breaks under concurrent
+                // rendering.
+                return { listItems };
             }
         }
 
-        return changed ? newState : null;
+        return null;
     }
 
     componentDidUpdate(prevProps: TreeViewProps): void {


### PR DESCRIPTION
`TreeView.getDerivedStateFromProps` wrote the freshly prepared `listItems` directly into the state object it was handed and returned an empty object. That works only because the mutation bypasses React: the contract is to return the partial state and let React apply it, and under React 19's concurrent rendering (in use since v4.0.0) an in-place mutation of the incoming state is not guaranteed to survive.

Behaviour is unchanged — same deep compare (still needed, because the caller mutates its `objects` record in place, so only content can tell whether the list moved), same resulting state — the update just travels the supported path now.

## Verification

`tsc --noEmit`, `eslint` and a full `vite build` of `src-admin` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)