### PR TITLE
Delete manually added states together with their device

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -92,6 +92,7 @@ import {
     copyDevice,
     findMainStateId,
     getLastPart,
+    getAddedChannelStates,
     getParentId,
     getSmartName,
     getStateCommonType,
@@ -3410,6 +3411,17 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
             if (state.id) {
                 const id = state.id;
                 await this.props.socket.delObject(id);
+            }
+        }
+
+        // Also delete the states the type-detector did not map (manually added ones).
+        // copyDevice copies them via getAddedChannelStates, but they are not part of
+        // device.states, so a move/rename (copy + delete) or a plain delete left them
+        // behind under the old channel as orphans.
+        const addedStates = getAddedChannelStates(device, this.objects);
+        for (let i = 0; i < addedStates.length; i++) {
+            if (addedStates[i].id) {
+                await this.props.socket.delObject(addedStates[i].id);
             }
         }
 


### PR DESCRIPTION
When a user renames or moves an alias device that has a manually added state (one added via "Add state", not mapped by the type-detector), the old object path stays behind as a ghost holding exactly that state — reported with screenshots in #684 (points 1 and 2). The same happens with the plain delete button, although its tooltip promises "Delete device with all states".

The cause is an asymmetry between the copy and the delete side of the move/rename flow: `copyDevice` explicitly includes the added states via `getAddedChannelStates`, but `deleteDevice` only walks `device.states` — the type-detector slots — and then deletes the channel object. Manually added states are in neither list, so they survive every move, rename and device deletion.

The fix makes the delete side use the same `getAddedChannelStates` enumeration the copy side already uses, so both halves of a move/rename cover the identical set of objects.

Proven against the real helper functions with a scripted object tree (one detector slot plus one added state): the copy includes the added state, the previous deletion enumeration missed it, the fixed one covers it. `check-ts`, `eslint` and the vite build are green.

This addresses the ghost-object part (points 1 and 2) of #684. The naming inconsistencies described there as points 3 and 4 are a separate mechanism and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)