### PR TITLE
Fix room column filter poisoning the function filter

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -2507,9 +2507,9 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                 style={{ width: '100%' }}
                 lang={I18n.getLanguage()}
                 themeType={this.props.themeType}
-                value={this.state.filter.func || '_'}
+                value={this.state.filter.room || '_'}
                 list={list}
-                onChange={text => this.changeFilter(text)}
+                onChange={text => this.changeFilter(undefined, text)}
             />
         );
     }


### PR DESCRIPTION
Selecting a room in the room column filter empties the device list (#680). The room dropdown had a double copy-paste slip: it displayed the FUNCTION filter's value, and it passed its selection as the first argument of `changeFilter()` — which is `func`. The chosen room enum id then sat in the function filter, where `device.functions.includes('enum.rooms.…')` can never match, so everything filtered away. The type filter next to it calls the correct third argument, which is exactly why the reporter saw it working.

The dropdown now shows `filter.room` and passes the selection as the second (room) argument — two tokens, no other logic touched. `check-ts`, `eslint` and the vite build are green.

Fixes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)