### PR TITLE
Inherit min/max/step from the alias source only for numeric states

### DIFF
--- a/src-admin/src/Components/helpers/utils.ts
+++ b/src-admin/src/Components/helpers/utils.ts
@@ -357,11 +357,16 @@ export function inheritCommonFromSource(
         aliasCommon.states = sourceCommon.states;
         changed = true;
     }
-    if (aliasCommon.min === undefined && sourceCommon.min !== undefined) {
+    // min/max/step only make sense on numeric states, and the object schema forbids them
+    // elsewhere ("obj.common.min is only allowed on obj.common.type 'number' or 'mixed'").
+    // A string-typed alias (e.g. the ERROR template state) linked to a source that carries
+    // min/max would otherwise inherit them and become an invalid object.
+    const numeric = aliasCommon.type === 'number' || aliasCommon.type === 'mixed';
+    if (numeric && aliasCommon.min === undefined && sourceCommon.min !== undefined) {
         aliasCommon.min = sourceCommon.min;
         changed = true;
     }
-    if (aliasCommon.max === undefined && sourceCommon.max !== undefined) {
+    if (numeric && aliasCommon.max === undefined && sourceCommon.max !== undefined) {
         aliasCommon.max = sourceCommon.max;
         changed = true;
     }
@@ -369,7 +374,7 @@ export function inheritCommonFromSource(
         aliasCommon.unit = sourceCommon.unit;
         changed = true;
     }
-    if (aliasCommon.step === undefined && sourceCommon.step !== undefined) {
+    if (numeric && aliasCommon.step === undefined && sourceCommon.step !== undefined) {
         aliasCommon.step = sourceCommon.step;
         changed = true;
     }


### PR DESCRIPTION
Linking a string datapoint to the ERROR template state produces an invalid object and a js-controller warning on every check (#682): the created alias is string-typed (the ERROR template's default type is string), but `inheritCommonFromSource` copied `min`/`max`/`step` from the source without looking at the alias type — and the object schema only allows those fields on `number` or `mixed` states.

The range fields are now inherited only when the alias itself is `number` or `mixed`; the `unit` keeps flowing for every type. Proven against the bundled helper: a string alias no longer inherits min/max/step (previously it did), while number and mixed aliases inherit exactly as before — the #22 behaviour is preserved.

Note: this prevents new invalid objects; existing ones keep their stray `min` until edited. The outdated wording of the warning itself ("This will throw an error up from js-controller version 7.0.0!") comes from js-controller, not from this adapter.

Addresses #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)