### PR TITLE
linkeddevices: inherit the real source range instead of writing 0/100

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -3094,24 +3094,20 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
                         }
                         common.type = getStateCommonType(state);
 
-                        /*if (state.defaultMin !== undefined) {
-                            common.min = state.defaultMin;
-                        } else */
-                        if (state.min !== undefined) {
-                            common.min = 0;
-                        }
+                        // Inherit min/max/unit/step from the linked source state — same fix the
+                        // alias path received for issue #22. The previous code wrote a hard
+                        // 0/100 whenever the pattern declares a min/max TYPE MARKER (its value
+                        // is the string 'number', not a number), overwriting the real source
+                        // range: a linked thermostat showed 0..100 instead of e.g. 5..35.
+                        inheritCommonFromSource(common, await this.getAliasSourceCommon(data.ids[state.name]));
 
-                        /*if (state.defaultMax !== undefined) {
-                            common.max = state.defaultMax;
-                        } else */
-                        if (state.max !== undefined) {
-                            common.max = 100;
-                        }
-
-                        if (state.defaultUnit) {
-                            common.unit = state.defaultUnit;
-                        } else if (state.unit) {
-                            common.unit = state.unit;
+                        // Fall back to the pattern's default unit if the source has none.
+                        if (!common.unit) {
+                            if (state.defaultUnit) {
+                                common.unit = state.defaultUnit;
+                            } else if (state.unit) {
+                                common.unit = state.unit;
+                            }
                         }
 
                         // Update states of state


### PR DESCRIPTION
Creating a linked-devices state whose template declares a range still writes a hard `min=0/max=100` into the state, overwriting the real range of the linked source — a linked thermostat shows 0..100 instead of e.g. 5..35, and widgets scale accordingly wrong.

This is the same defect issue #22 reported for alias devices. The fix back then (`inheritCommonFromSource` at both alias mapping sites) left this third site untouched — the original commented-out `defaultMin` code still sits next to it. Testing `state.min !== undefined` was never meaningful here: in the templates `min`/`max` are TYPE MARKERS whose value is the string `'number'`, so the check only means "this slot may have a range" and the code then wrote literal 0/100.

The linked path now inherits `min`/`max`/`unit`/`step` from the source state exactly like the alias path does, with the template's default unit as a fallback. Companion to the type guard proposed in #689 — together they make range inheritance both present and type-safe on every mapping path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)