### PR TITLE
Keep the device list alive when a device has no mandatory datapoint

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -1231,8 +1231,13 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
         this.funcEnums = this.enumIDs.filter(id => id.startsWith('enum.functions.'));
         this.roomsEnums = this.enumIDs.filter(id => id.startsWith('enum.rooms.'));
 
-        // find channelID for every device
-        devices.map(device => this.updateEnumsForOneDevice(device, this.funcEnums, this.roomsEnums));
+        // Find the channelID for every device, and drop the ones that have none: a single
+        // undescribable device must not cost the whole list (see updateEnumsForOneDevice).
+        for (let d = devices.length - 1; d >= 0; d--) {
+            if (!this.updateEnumsForOneDevice(devices[d], this.funcEnums, this.roomsEnums)) {
+                devices.splice(d, 1);
+            }
+        }
 
         const listItems = this.onObjectsGenerate(
             this.objects || {},
@@ -1440,37 +1445,56 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
         return prepareList(stateIds, null, objects);
     };
 
-    updateEnumsForOneDevice(device: PatternControlEx, funcEnums?: string[] | null, roomsEnums?: string[] | null): void {
+    /**
+     * Fill in the channel id, enums, name and icon of one detected device.
+     *
+     * @param device Detected device
+     * @param funcEnums Function enum ids; read from `enumIDs` when not passed
+     * @param roomsEnums Room enum ids; read from `enumIDs` when not passed
+     * @returns whether the device could be described. Everything below the channel — enums, name,
+     * icon — is derived from the mandatory state, so a device without one cannot be listed and the
+     * caller drops it.
+     */
+    updateEnumsForOneDevice(
+        device: PatternControlEx,
+        funcEnums?: string[] | null,
+        roomsEnums?: string[] | null,
+    ): boolean {
         funcEnums ||= this.enumIDs.filter(id => id.startsWith('enum.functions.'));
         roomsEnums ||= this.enumIDs.filter(id => id.startsWith('enum.rooms.'));
         if (!device) {
-            return;
+            return false;
         }
         const mainStateId = findMainStateId(device);
-
-        if (mainStateId) {
-            const statesCount = device.states.filter(state => state.id).length;
-            let channelId = mainStateId;
-            if (
-                mainStateId.includes('.') &&
-                (statesCount > 1 || channelId.startsWith(ALIAS) || channelId.startsWith(LINKEDDEVICES))
-            ) {
-                channelId = getParentId(mainStateId);
-                if (
-                    !this.objects[channelId]?.common ||
-                    (this.objects[channelId].type !== 'channel' &&
-                        this.objects[channelId].type !== 'device' &&
-                        this.objects[channelId].type !== 'folder')
-                ) {
-                    channelId = mainStateId;
-                }
-            }
-
-            device.channelId = channelId;
-        } else {
-            // Should never happen!!
-            throw new Error(`Device without main state: ${JSON.stringify(device)}`);
+        if (!mainStateId) {
+            // Reachable: `chart` is the one type-detector pattern that declares no mandatory state
+            // at all, so an echarts object that is a member of a room or function is detected and
+            // arrives here. Throwing aborted the whole list rebuild before `loading` was cleared,
+            // and `onObjectChanged` returns early while `loading` is set, so nothing retried: the
+            // devices tab stayed on its loading spinner for good — including every device already
+            // processed. The backend twin `resolveChannelId` (src/lib/WidgetsManagement.ts) skips
+            // such a device instead, and this now does the same.
+            return false;
         }
+
+        const statesCount = device.states.filter(state => state.id).length;
+        let channelId = mainStateId;
+        if (
+            mainStateId.includes('.') &&
+            (statesCount > 1 || channelId.startsWith(ALIAS) || channelId.startsWith(LINKEDDEVICES))
+        ) {
+            channelId = getParentId(mainStateId);
+            if (
+                !this.objects[channelId]?.common ||
+                (this.objects[channelId].type !== 'channel' &&
+                    this.objects[channelId].type !== 'device' &&
+                    this.objects[channelId].type !== 'folder')
+            ) {
+                channelId = mainStateId;
+            }
+        }
+
+        device.channelId = channelId;
 
         const functions = funcEnums.filter(id => {
             const obj = this.objects[id];
@@ -1519,6 +1543,7 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
             }
         }
         // all new created or modified objects will be reported to onObjectChange and there is no need to update
+        return true;
     }
 
     searchIcon = (channelId: string): string | null => {


### PR DESCRIPTION
## Problem

`updateEnumsForOneDevice` throws `Device without main state` when a detected device has no mandatory datapoint to derive its channel from:

```ts
} else {
    // Should never happen!!
    throw new Error(`Device without main state: ${JSON.stringify(device)}`);
}
```

The call sits in a synchronous loop over every detected device inside `updateListItems`, so the throw aborts the whole rebuild **before** `setState({ loading: false })` is ever reached. Nothing catches it: `detectDevices` is started as `void` from the constructor.

What the user sees: `loading` starts as `true`, `render()` shows only the `<Loader>` while it is set, and `onObjectChanged` returns early while `loading` is set — so there is no retry either. **The devices tab never leaves its loading spinner**, and reloading the page does the same again. If the tab was already open when the offending object appeared, the list simply stops updating and freezes into the spinner on the next visit.

## It does happen

Of the 51 patterns in `@iobroker/type-detector` 6.0.1 (the version pinned by this repo's lockfile), exactly one declares no mandatory state at all — `chart`, which matches the objects the **echarts** adapter creates. The pattern is part of the shipped 4.2.0 bundle (`admin/assets/index-*.js`: `` patterns={chart:{states:[{objectType:`chart`,name:`CHART`}],type:Types.chart} ``).

And it is reachable: `updateListItems` collects enum members **without a type filter** (the `channel`/`device` filter applies only to the `alias.` / `linkeddevices.` branch below it). Assigning a chart to a room or a function is therefore enough.

Measured against the bundled library, with one room holding a light and a chart:

```
idsInEnums: [ 'alias.0.Living.Light', 'echarts.0.Power' ]
detected:   light, chart
=> throw - the already-detected light is lost together with the rest
```

### How a chart gets into a room

Through the normal object browser, in expert mode. Source (`@iobroker/gui-components`, `ObjectBrowser/contextMenu.tsx`, same condition again in `renderLeaf.tsx`):

```js
const enumEditable = !that.props.notEditable && obj &&
    (that.state.filter.expertMode || obj.type === 'state' || obj.type === 'channel' || obj.type === 'device');
```

Outside expert mode the assignment is limited to `state` / `channel` / `device`, but **expert mode bypasses the type check entirely**. Verified in the frontend bundle shipped with **iobroker.admin 8.0.11** — both occurrences are there, minified as `` expertMode||d.type===`state`||d.type===`channel`||d.type===`device` `` and `` expertMode||f===`state`||f===`channel`||f===`device` ``.

So: Objects tab → expert mode on → right-click an echarts chart → *Edit room*. Grouping charts by room is a plausible thing to want, and nothing warns that it takes the devices tab down.

## Fix

The backend already gets this right. `resolveChannelId` in `src/lib/WidgetsManagement.ts` faces the same situation, leaves `storeId` empty and returns; devices without a `storeId` are filtered out afterwards. Its comment even says *"same logic as updateEnumsForOneDevice"*.

This aligns the frontend with it: `updateEnumsForOneDevice` now reports whether the device could be described, and the caller drops the ones that could not, instead of losing the entire list over a single entry.

Addresses #697 — the symptom reported there (devices tab shows nothing, blank window) matches this, but the report carries no object list, so this is not claimed as a fix for it.

## Notes

- `src-admin`: `tsc --noEmit` and `eslint` both clean.
- Source-only, no lockfiles touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)