### PR TITLE
Expand the folders on first load instead of nothing

### DIFF
--- a/src-admin/src/Components/TreeView.tsx
+++ b/src-admin/src/Components/TreeView.tsx
@@ -308,7 +308,7 @@ export default class TreeView extends React.Component<TreeViewProps, TreeViewSta
 
         if (expanded === null) {
             expanded = [];
-            listItems.forEach(item => item.parent && expanded!.includes(item.parent) && expanded!.push(item.parent));
+            listItems.forEach(item => item.parent && !expanded!.includes(item.parent) && expanded!.push(item.parent));
         }
 
         this.state = {

--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -1243,7 +1243,7 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
         if (expandedIDs === null) {
             expandedIDs = [];
             listItems.forEach(
-                item => item.parent && expandedIDs!.includes(item.parent) && expandedIDs!.push(item.parent),
+                item => item.parent && !expandedIDs!.includes(item.parent) && expandedIDs!.push(item.parent),
             );
         }
 


### PR DESCRIPTION
Both list builders try to expand the folders that have children when there is no saved expansion state yet, and both test the wrong way round:

```js
expandedIDs = [];
listItems.forEach(item => item.parent && expandedIDs.includes(item.parent) && expandedIDs.push(item.parent));
```

The array was just emptied, so `includes` is always `false` and the `push` is unreachable — the loop does nothing at all. It has to be `!includes`: take the parent *unless* it is already noted.

`onExpandAll` in the same file does exactly that, which is what these two lines were meant to do for the initial build. Without the fix, a user opening the tab for the first time — or after clearing browser storage — sees every folder closed.

Same line and same effect in `Tabs/ListDevices.tsx` and `Components/TreeView.tsx`, so both are corrected.

`src-admin`: `tsc --noEmit` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)