### PR TITLE
Drop the stray apostrophe from the adapter icon path

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -194,7 +194,7 @@ const prepareList = (
 
         let icon = obj.common.icon || null;
         if (icon && typeof icon === 'string' && !icon.includes('/')) {
-            icon = `'../../adapter/${(obj.obj?._id || ids[i]).split('.')[0]}/${icon}`;
+            icon = `../../adapter/${(obj.obj?._id || ids[i]).split('.')[0]}/${icon}`;
         }
 
         result.push({
@@ -1329,7 +1329,7 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
             if (icon && !icon.includes('/')) {
                 // add adapter prefix
                 const parts = id.split('.');
-                icon = `'../../adapter/${parts[0]}/${icon}`;
+                icon = `../../adapter/${parts[0]}/${icon}`;
             }
 
             stateIds[id] = {


### PR DESCRIPTION
An icon stored as a bare file name gets the adapter directory put in front of it. Two of the three places that do this start the template string with an apostrophe:

```js
icon = `'../../adapter/${parts[0]}/${icon}`;
```

The resulting `src` is `'../../adapter/hm-rpc/icon.png`, which no browser resolves — those icons simply never appear.

The third place, the `linkeddevices` branch a few lines below, builds the same path correctly (`` `../../adapter/…` ``), and that is what the other two are corrected to.

Affected: `prepareList` and `onObjectsGenerate` in `Tabs/ListDevices.tsx`.

`src-admin`: `tsc --noEmit` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)