### PR TITLE
Let the search find a device by its name, whatever its case

### DIFF
--- a/src-admin/src/Tabs/ListDevices.tsx
+++ b/src-admin/src/Tabs/ListDevices.tsx
@@ -1766,7 +1766,7 @@ export default class ListDevices extends Component<ListDevicesProps, ListDevices
             if (
                 item.visible &&
                 filter.text &&
-                !item.title.includes(filter.text) &&
+                !item.title.toLowerCase().includes(filter.text) &&
                 !item.id.toLowerCase().includes(filter.text)
             ) {
                 item.visible = false;


### PR DESCRIPTION
The filter text is lower-cased wherever it is set (`setFilter`, `changeFilter`). `applyFilter` compares it against the id in lower case — but against the title as it is:

```js
!item.title.includes(filter.text) &&
!item.id.toLowerCase().includes(filter.text)
```

So a device is only found through its displayed name when that name happens to be all lower case. Everything else is found through the object id alone — which fails exactly for the devices whose name was changed and no longer resembles their id.

The highlighting of the hit a few lines below already lower-cases the title (`title.toLowerCase().indexOf(...)`), so filter and display disagreed with each other.

`src-admin`: `tsc --noEmit` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)