### PR TITLE
Clear the widget notification timer on unload

### DIFF
--- a/src/lib/WidgetsManagement.ts
+++ b/src/lib/WidgetsManagement.ts
@@ -719,6 +719,22 @@ export default class DevicesWidgetsManagement extends WidgetsManagement<DevicesA
         }, 100);
     }
 
+    /**
+     * The adapter is shutting down.
+     *
+     * The base class has nothing to tear down, but the debounce timer above does outlive an
+     * unload: its callback talks to the GUI through an adapter that is already gone. Under
+     * `common.mode: daemon` the process ends anyway, but this adapter also runs in compact mode,
+     * where it does not.
+     */
+    public override destroy(): void {
+        if (this.notifyTimeout) {
+            clearTimeout(this.notifyTimeout);
+            this.notifyTimeout = null;
+        }
+        super.destroy();
+    }
+
     // ── Object change (incremental) ───────────────────────────────────
 
     public objectChange(id: string, obj: ioBroker.Object | null | undefined): void {


### PR DESCRIPTION
`unload` calls `widgetsManagement.destroy()` before the callback, which is right. But `destroy()` comes from the base class in `src/widget-utils/WidgetsManagement.ts` and is empty:

```ts
public destroy(): void {
    // do nothing
}
```

`DevicesWidgetsManagement` does not override it, while `scheduleNotify` keeps a 100 ms debounce timer whose callback reaches the GUI through `sendCommandToGui` — on an adapter that is already gone.

Under `common.mode: daemon` the process ends right afterwards, so it goes unnoticed. This adapter also exports a constructor for compact mode (`require.main !== module` in `main.ts`), and there the process does *not* end, so the timer stays behind.

`tsc -p tsconfig.build.json` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)