### PR TITLE
Do not warn about the web configuration when there is no web instance

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -280,6 +280,7 @@ export default class DevicesAdapter extends Adapter {
     private async checkWebInstances(): Promise<void> {
         try {
             let found = false;
+            let webInstances = 0;
             const res = await this.getObjectViewAsync('system', 'instance', {
                 startkey: 'system.adapter.web.',
                 endkey: 'system.adapter.web.香',
@@ -290,6 +291,7 @@ export default class DevicesAdapter extends Adapter {
                 if (!/^system\.adapter\.web\.\d+$/.test(id)) {
                     continue;
                 }
+                webInstances++;
                 const native = (row.value?.native || {}) as { usePureWebSockets?: boolean; socketio?: string };
                 if (!native.socketio && native.usePureWebSockets) {
                     found = true;
@@ -300,7 +302,9 @@ export default class DevicesAdapter extends Adapter {
                     break;
                 }
             }
-            if (!found) {
+            // Nothing to configure on a system that has no web instance at all — the warning
+            // would name a setting the user cannot reach.
+            if (webInstances && !found) {
                 this.log.warn(
                     `web instance is not configured for the devices GUI — enable "Pure Web Sockets" or set "Socket.io adapter" to a "ws.X" instance, otherwise the widget view will hang.`,
                 );


### PR DESCRIPTION
`checkWebInstances` sets `found` inside the loop over the installed `system.adapter.web.<n>` instances. On a system that has none, the loop body never runs, `found` stays `false`, and the warning is logged anyway:

> web instance is not configured for the devices GUI — enable "Pure Web Sockets" or set "Socket.io adapter" to a "ws.X" instance, otherwise the widget view will hang.

It then names a setting the user cannot reach, because there is no web instance to configure.

The fix counts the instances that were actually examined and warns only when at least one exists and none of them fits.

(Not related to #673 — the reporter there does have a web instance; this is only about the case where none is installed.)

`tsc -p tsconfig.build.json` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)