### PR TITLE
Survive a missing enum object while importing, and fix a style typo

### DIFF
--- a/src-admin/src/Dialogs/DialogImporter.tsx
+++ b/src-admin/src/Dialogs/DialogImporter.tsx
@@ -140,7 +140,7 @@ const styles: Record<string, any> = {
         display: 'flex',
         flexDirection: 'column',
         background: '#00000057',
-        m: '10üx',
+        m: '10px',
         p: '4px',
         borderRadius: '4px',
         mb: '10px',
@@ -510,11 +510,16 @@ export default function DialogImporter(props: {
                     if (!objects[newId]) {
                         const newObjFolder = objects[device.rooms[0]];
                         await addNewFolder(
-                            {
-                                objName: newObjFolder.common.name,
-                                color: newObjFolder.common.color,
-                                icon: newObjFolder.common.icon,
-                            },
+                            newObjFolder?.common
+                                ? {
+                                      objName: newObjFolder.common.name,
+                                      color: newObjFolder.common.color,
+                                      icon: newObjFolder.common.icon,
+                                  }
+                                : // The enum is read from the local object cache and may be
+                                  // missing there; the folder is still created, named after the
+                                  // id it is about to get.
+                                  { name: getLastPart(newId) },
                             newId,
                         );
                         await addDevice(newId, el);
@@ -527,11 +532,16 @@ export default function DialogImporter(props: {
                     if (!objects[newId]) {
                         const newObjFolder = objects[device.functions[0]];
                         await addNewFolder(
-                            {
-                                objName: newObjFolder.common.name,
-                                color: newObjFolder.common.color,
-                                icon: newObjFolder.common.icon,
-                            },
+                            newObjFolder?.common
+                                ? {
+                                      objName: newObjFolder.common.name,
+                                      color: newObjFolder.common.color,
+                                      icon: newObjFolder.common.icon,
+                                  }
+                                : // The enum is read from the local object cache and may be
+                                  // missing there; the folder is still created, named after the
+                                  // id it is about to get.
+                                  { name: getLastPart(newId) },
                             newId,
                         );
                         await addDevice(newId, el);


### PR DESCRIPTION
### The import dies on an enum that is not in the cache

Importing grouped by room or by function creates one folder per enum and takes its name, colour and icon from the enum object:

```js
const newObjFolder = objects[device.rooms[0]];
await addNewFolder({
    objName: newObjFolder.common.name,
    color: newObjFolder.common.color,
    icon: newObjFolder.common.icon,
}, newId);
```

`objects` is the local cache, so that entry can be absent — the enum was created after the cache was filled, or it no longer exists. The import then dies with a `TypeError` halfway through and leaves the devices copied so far behind.

The folder is now created either way; without the enum object it is named after the id it is about to get. `addNewFolder` already accepts that shape (`{ name }` instead of `{ objName }`), so nothing new is introduced.

Both branches — rooms and functions — had the same unguarded access.

### `m: '10üx'`

A typo in the header style. MUI drops the value silently, so the header never had the margin it asks for.

`src-admin`: `tsc --noEmit` and `eslint` clean. Source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)